### PR TITLE
Amlogic settings improvement

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8355,7 +8355,17 @@ msgctxt "#14283"
 msgid "Intended for HDR enabled displays - not recommended. Turn this On or set to Auto to have HDR10 mode always on. GUI and SDR content will be tone mapped. Requires reboot."
 msgstr ""
 
-#empty strings from id 14284 to 14300
+#: system/settings/settings.xml
+msgctxt "#14284"
+msgid "Tone map HDR to SDR"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14285"
+msgid "Intended for SDR displays. Turn this On or set to Auto to have HDR content tone mapped to SDR. This improves color saturation and contrast of HDR content on SDR displays. Requires reboot."
+msgstr ""
+
+#empty strings from id 14286 to 14300
 
 #. pvr "channels" settings group label
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8337,25 +8337,25 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14280"
-msgid "Enable HEVC seek workaround"
+msgid "Enable HEVC workaround"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14281"
-msgid "Enable this if you have problems with HEVC content after seeking."
+msgid "Enable this if you have playback issues with HEVC content."
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14282"
-msgid "SDR2HDR mode"
+msgid "Tone map SDR to HDR"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14283"
-msgid "Select to change the SDR2HDR mode. Requires reboot."
+msgid "Intended for HDR enabled displays - not recommended. Turn this On or set to Auto to have HDR10 mode always on. GUI and SDR content will be tone mapped. Requires reboot."
 msgstr ""
 
-#empty strings from id 14282 to 14300
+#empty strings from id 14284 to 14300
 
 #. pvr "channels" settings group label
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3013,7 +3013,7 @@
         <setting id="coreelec.amlogic.hevcworkaround" type="boolean" label="14280" help="14281">
           <requirement>HAVE_AMCODEC</requirement>
           <level>3</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
       </group>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3008,6 +3008,18 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="coreelec.amlogic.hdr2sdr" type="integer" label="14284" help="14285">
+          <requirement>HAVE_AMCODEC</requirement>
+          <default>2</default> <!-- AUTO -->
+          <constraints>
+            <options>
+              <option label="351">0</option> <!-- OFF -->
+              <option label="16041">1</option> <!-- ON -->
+              <option label="16316">2</option> <!-- AUTO -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
       <group id="2" label="14086">
         <setting id="coreelec.amlogic.hevcworkaround" type="boolean" label="14280" help="14281">

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -395,6 +395,7 @@ const std::string CSettings::SETTING_MASTERLOCK_STARTUPLOCK = "masterlock.startu
 const std::string CSettings::SETTING_MASTERLOCK_MAXRETRIES = "masterlock.maxretries";
 const std::string CSettings::SETTING_COREELEC_AMLOGIC_HEVCWORKAROUND = "coreelec.amlogic.hevcworkaround";
 const std::string CSettings::SETTING_COREELEC_AMLOGIC_SDR2HDR = "coreelec.amlogic.sdr2hdr";
+const std::string CSettings::SETTING_COREELEC_AMLOGIC_HDR2SDR = "coreelec.amlogic.hdr2sdr";
 const std::string CSettings::SETTING_CACHE_HARDDISK = "cache.harddisk";
 const std::string CSettings::SETTING_CACHEVIDEO_DVDROM = "cachevideo.dvdrom";
 const std::string CSettings::SETTING_CACHEVIDEO_LAN = "cachevideo.lan";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -355,6 +355,7 @@ public:
   static const std::string SETTING_MASTERLOCK_MAXRETRIES;
   static const std::string SETTING_COREELEC_AMLOGIC_HEVCWORKAROUND;
   static const std::string SETTING_COREELEC_AMLOGIC_SDR2HDR;
+  static const std::string SETTING_COREELEC_AMLOGIC_HDR2SDR;
   static const std::string SETTING_CACHE_HARDDISK;
   static const std::string SETTING_CACHEVIDEO_DVDROM;
   static const std::string SETTING_CACHEVIDEO_LAN;

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -85,7 +85,7 @@ bool CWinSystemAmlogic::InitWindowSystem()
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
   int sdr2hdr = settings->GetInt(CSettings::SETTING_COREELEC_AMLOGIC_SDR2HDR);
-  if (sdr2hdr)
+  if (sdr2hdr != 0) // Default is Off (0)
   {
     CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- setting sdr2hdr mode to %d", sdr2hdr);
     SysfsUtils::SetInt("/sys/module/am_vecm/parameters/sdr_mode", sdr2hdr);

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -91,6 +91,13 @@ bool CWinSystemAmlogic::InitWindowSystem()
     SysfsUtils::SetInt("/sys/module/am_vecm/parameters/sdr_mode", sdr2hdr);
   }
 
+  int hdr2sdr = settings->GetInt(CSettings::SETTING_COREELEC_AMLOGIC_HDR2SDR);
+  if (hdr2sdr != 2) // Default is Auto (2)
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- setting hdr2sdr mode to %d", hdr2sdr);
+    SysfsUtils::SetInt("/sys/module/am_vecm/parameters/hdr_mode", hdr2sdr);
+  }
+
   m_nativeDisplay = EGL_DEFAULT_DISPLAY;
 
   CDVDVideoCodecAmlogic::Register();


### PR DESCRIPTION
Add better description for the SDR to HDR and HEVC workaround configurations.
Change HEVC workaround default state to On.
Add HDR to SDR configuration.