### PR TITLE
Further improvements for Framebuffer handling

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2170,6 +2170,11 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="coreelec.amlogic.disableguiscaling" type="boolean" parent="videoscreen.screen" label="14290" help="14291">
+          <requirement>HAVE_4K_GUI</requirement>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoscreen.delayrefreshchange" type="integer" parent="videoscreen.screen" label="13550" help="36165">
           <level>2</level>
           <default>0</default>
@@ -3034,11 +3039,6 @@
         </setting>
         <setting id="coreelec.amlogic.force422" type="boolean" label="14288" help="14289">
           <requirement>HAVE_AMCODEC</requirement>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="coreelec.amlogic.disableguiscaling" type="boolean" label="14290" help="14291">
-          <requirement>HAVE_4K_GUI</requirement>
           <default>false</default>
           <control type="toggle" />
         </setting>

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -88,6 +88,35 @@ static std::string ModeFlagsToString(unsigned int flags, bool identifier)
   return res;
 }
 
+static bool write_resolution_ini(RESOLUTION_INFO res)
+{
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  struct statfs fsInfo;
+  std::string aml_res_path = "/flash";
+  std::string aml_res_file = "resolution.ini";
+  auto result = statfs(aml_res_path.c_str(), &fsInfo);
+  const bool nativeGui = settings->GetBool(CSettings::SETTING_COREELEC_AMLOGIC_DISABLEGUISCALING);
+
+  if (!result && fsInfo.f_flags & MS_RDONLY)
+    result = mount(NULL, aml_res_path.c_str(), NULL, MS_NOATIME | MS_REMOUNT, NULL);
+
+  if (!result)
+  {
+    std::ofstream ofs(aml_res_path + "/" + aml_res_file, std::ofstream::out);
+    ofs << "# WARNING DO NOT MODIFY THIS FILE! ALL CHANGES WILL BE LOST!\n";
+    ofs << "hdmimode=" << res.strId.c_str() << "\n";
+    ofs << "frac_rate_policy=" << std::to_string((res.fRefreshRate == floor(res.fRefreshRate)) ? 0 : 1).c_str() << "\n";
+    ofs << "native_4k_gui=" << std::to_string(nativeGui).c_str() << "\n";
+    ofs.close();
+    CLog::Log(LOGDEBUG, "CDisplaySettings: Amlogic resolution got saved to %s/%s", aml_res_path.c_str(), aml_res_file.c_str());
+  }
+
+  if (!result && fsInfo.f_flags & MS_RDONLY)
+    mount(NULL, aml_res_path.c_str(), NULL, MS_RDONLY | MS_NOATIME | MS_REMOUNT, NULL);
+
+  return true;
+}
+
 CDisplaySettings::CDisplaySettings()
 {
   m_resolutions.resize(RES_CUSTOM);
@@ -345,6 +374,11 @@ bool CDisplaySettings::OnSettingChanging(std::shared_ptr<const CSetting> setting
 #endif
   }
 #endif
+  else if (settingId == CSettings::SETTING_COREELEC_AMLOGIC_DISABLEGUISCALING)
+  {
+    const RESOLUTION_INFO res_info = GetResolutionInfo(GetCurrentResolution());
+    write_resolution_ini(res_info);
+  }
 
   return true;
 }
@@ -424,30 +458,11 @@ void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* 
   }
   else if (resolution != m_currentResolution)
   {
-    struct statfs fsInfo;
-    std::string aml_res_path = "/flash";
-    std::string aml_res_file = "resolution.ini";
-    auto result = statfs(aml_res_path.c_str(), &fsInfo);
 
     m_currentResolution = resolution;
+    const RESOLUTION_INFO res_info = GetResolutionInfo(m_currentResolution);
     SetChanged();
-
-    if (!result && fsInfo.f_flags & MS_RDONLY)
-      result = mount(NULL, aml_res_path.c_str(), NULL, MS_NOATIME | MS_REMOUNT, NULL);
-
-    if (!result)
-    {
-      const RESOLUTION_INFO res = GetResolutionInfo(m_currentResolution);
-      std::ofstream ofs(aml_res_path + "/" + aml_res_file, std::ofstream::out);
-      ofs << "# WARNING DO NOT MODIFY THIS FILE! ALL CHANGES WILL BE LOST!\n";
-      ofs << "hdmimode=" << res.strId.c_str() << "\n";
-      ofs << "frac_rate_policy=" << std::to_string((res.fRefreshRate == floor(res.fRefreshRate)) ? 0 : 1).c_str() << "\n";
-      ofs.close();
-      CLog::Log(LOGDEBUG, "CDisplaySettings: Amlogic resolution got saved to %s/%s", aml_res_path.c_str(), aml_res_file.c_str());
-    }
-
-    if (!result && fsInfo.f_flags & MS_RDONLY)
-      mount(NULL, aml_res_path.c_str(), NULL, MS_RDONLY | MS_NOATIME | MS_REMOUNT, NULL);
+    write_resolution_ini(res_info);
   }
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -848,6 +848,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_SCREEN);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_RESOLUTION);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_SCREENMODE);
+  settingSet.insert(CSettings::SETTING_COREELEC_AMLOGIC_DISABLEGUISCALING);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_MONITOR);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_3DLUT);

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -714,13 +714,16 @@ void aml_set_framebuffer_resolution(int width, int height, std::string framebuff
     struct fb_var_screeninfo vinfo;
     if (ioctl(fd0, FBIOGET_VSCREENINFO, &vinfo) == 0)
     {
-      vinfo.xres = width;
-      vinfo.yres = height;
-      vinfo.xres_virtual = width;
-      vinfo.yres_virtual = height * 2;
-      vinfo.bits_per_pixel = 32;
-      vinfo.activate = FB_ACTIVATE_ALL;
-      ioctl(fd0, FBIOPUT_VSCREENINFO, &vinfo);
+      if (width != vinfo.xres || height != vinfo.yres)
+      {
+        vinfo.xres = width;
+        vinfo.yres = height;
+        vinfo.xres_virtual = width;
+        vinfo.yres_virtual = height * 2;
+        vinfo.bits_per_pixel = 32;
+        vinfo.activate = FB_ACTIVATE_ALL;
+        ioctl(fd0, FBIOPUT_VSCREENINFO, &vinfo);
+      }
     }
     close(fd0);
   }

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -144,7 +144,8 @@ bool CWinSystemAmlogic::InitWindowSystem()
   RETRO::CRPProcessInfoAmlogic::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
   CRendererAML::Register();
 
-  aml_set_framebuffer_resolution(1920, 1080, m_framebuffer_name);
+  if (aml_get_cpufamily_id() <= AML_GXL)
+    aml_set_framebuffer_resolution(1920, 1080, m_framebuffer_name);
 
   return CWinSystemBase::InitWindowSystem();
 }


### PR DESCRIPTION

This will require CoreELEC platform_init and boot.ini changes to work as expected. It will fix the framebuffer corruption what we see when mediacenter scales to hardcoded 1080p and then back to the correct resolution.
Unfortunately it cannot be fixed on gxl because of the mali bug, but new devices can benefit from flicker free boot.
Works with native 4K GUI or with scaled one (with platform_init changes). Although there is a weird scale going on for Scaled mode which is probably due to free_scale. I will have a look into it.