### PR TITLE
Peripherals: CEC put devices on standby if video is paused

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17956,12 +17956,22 @@ msgctxt "#36049"
 msgid "Remote button press release time (ms)"
 msgstr ""
 
+#: system/peripherals.xml
+msgctxt "#36051"
+msgid "Seconds standby is delayed after Screensaver is activated"
+msgstr ""
+
+#: system/peripherals.xml
+msgctxt "#36052"
+msgid "Put devices in standby by Screensaver on paused video"
+msgstr ""
+
 #: system/settings.xml
 msgctxt "#36050"
 msgid "On start"
 msgstr ""
 
-#empty strings from id 36051 to 36098
+#empty strings from id 36053 to 36098
 
 #: system/settings/settings.xml
 msgctxt "#36099"

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -15,25 +15,27 @@
     <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
     <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
-    <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011|13010|13009|36044|36045" />
-    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
+    <setting key="cec_standby_screensaver_paused" type="bool" value="0" order="7" label="36052" />
+    <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="8" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="9" lvalues="36028|13005|13011|13010|13009|36044|36045" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="10" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
-    <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="11" lvalues="231|36044|36045" />
-    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="14" />
-    <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="15" />
+    <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="12" lvalues="231|36044|36045" />
+    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="13" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="14" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="15" />
+    <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="16" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />
     <setting key="device_type" type="int" value="1" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
-    <setting key="double_tap_timeout_ms" type="int" min="50" max="1000" step="50" value="300" label="36047" order="16" />
-    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="17" />
-    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="18" />
+    <setting key="double_tap_timeout_ms" type="int" min="50" max="1000" step="50" value="300" label="36047" order="17" />
+    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="18" />
+    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="19" />
+	<setting key="screensaver_delay_standby" type="int" min="0" max="7200" step="10" value="0" label="36051" order="20" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -107,11 +107,13 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_bUseTVMenuLanguage         = false;
   m_bSendInactiveSource        = false;
   m_bPowerOffScreensaver       = false;
+  m_bPowerOffScreensaverPaused = false;
   m_bShutdownOnStandby         = false;
 
   m_currentButton.iButton    = 0;
   m_currentButton.iDuration  = 0;
   m_standbySent.SetValid(false);
+  m_ScreensaverStandbySent.SetValid(false);
   m_configuration.Clear();
 }
 
@@ -127,6 +129,8 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const 
   else if (flag == ANNOUNCEMENT::GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverDeactivated") && m_bIsReady)
   {
     bool bIgnoreDeactivate(false);
+    m_ScreensaverStandbySent.SetValid(false);
+    m_bStandbyPending = false;
     if (data["shuttingdown"].isBoolean())
     {
       // don't respond to the deactivation if we are just going to suspend/shutdown anyway
@@ -144,12 +148,22 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const 
   }
   else if (flag == ANNOUNCEMENT::GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverActivated") && m_bIsReady)
   {
-    // Don't put devices to standby if application is currently playing
-    if (!g_application.GetAppPlayer().IsPlaying() && m_bPowerOffScreensaver)
+    if (m_bPowerOffScreensaver)
     {
-      // only power off when we're the active source
-      if (m_cecAdapter->IsLibCECActiveSource())
-        StandbyDevices();
+      // Don't put devices to standby if application is currently playing. Check if video is paused.
+      bool bNotPlaying = false;
+      if (m_bPowerOffScreensaverPaused)
+        bNotPlaying = (!g_application.GetAppPlayer().IsPlaying() || g_application.GetAppPlayer().IsPausedPlayback());
+      else
+        bNotPlaying = (!g_application.GetAppPlayer().IsPlaying());
+      if (bNotPlaying)
+      {
+        // only power off when we're the active source
+        if (m_cecAdapter->IsLibCECActiveSource()) {
+          m_ScreensaverStandbySent = CDateTime::GetCurrentDateTime();
+          StandbyDevices();
+	}
+      }
     }
   }
   else if (flag == ANNOUNCEMENT::System && !strcmp(sender, "xbmc") && !strcmp(message, "OnSleep"))
@@ -1349,6 +1363,7 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   m_bUseTVMenuLanguage                 = GetSettingBool("use_tv_menu_language") ? 1 : 0;
   m_configuration.bActivateSource      = GetSettingBool("activate_source") ? 1 : 0;
   m_bPowerOffScreensaver               = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
+  m_bPowerOffScreensaverPaused         = GetSettingBool("cec_standby_screensaver_paused") ? 1 : 0;
   m_bPowerOnScreensaver                = GetSettingBool("cec_wake_screensaver") ? 1 : 0;
   m_bSendInactiveSource                = GetSettingBool("send_inactive_source") ? 1 : 0;
   m_configuration.bAutoWakeAVR         = GetSettingBool("power_avr_on_as") ? 1 : 0;
@@ -1721,8 +1736,14 @@ void CPeripheralCecAdapter::ProcessStandbyDevices(void)
 
   {
     CSingleLock lock(m_critSection);
+    int iScreensaverDelay = GetSettingInt("screensaver_delay_standby");
+    if ((m_ScreensaverStandbySent.IsValid() &&
+        (CDateTime::GetCurrentDateTime() - m_ScreensaverStandbySent < CDateTimeSpan(0, 0, 0, iScreensaverDelay))) ||
+	(!m_cecAdapter->IsLibCECActiveSource()))
+      return;
     bStandby = m_bStandbyPending;
     m_bStandbyPending = false;
+    m_ScreensaverStandbySent.SetValid(false);
     if (bStandby)
       m_bGoingToStandby = true;
   }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -147,6 +147,7 @@ namespace PERIPHERALS
     bool m_bHasConnectedAudioSystem;
     std::string m_strMenuLanguage;
     CDateTime m_standbySent;
+    CDateTime m_ScreensaverStandbySent;
     std::vector<CecButtonPress> m_buttonQueue;
     CecButtonPress m_currentButton;
     std::queue<CecVolumeChange> m_volumeChangeQueue;
@@ -169,6 +170,7 @@ namespace PERIPHERALS
     bool m_bPlaybackPaused;
     std::string m_strComPort;
     bool m_bPowerOnScreensaver;
+	bool m_bPowerOffScreensaverPaused;
     bool m_bUseTVMenuLanguage;
     bool m_bSendInactiveSource;
     bool m_bPowerOffScreensaver;


### PR DESCRIPTION
This comes from user request: https://discourse.coreelec.org/t/tutorial-cec-turn-off-tv-when-idle-screensaver/11539
Currently if you have the option to turn TV off through CEC when mediacenter is idle it doesn't work when the playback is paused.
Since I own an OLED the fear of permanent burn-in gives me sleepless nights. So I have set my Screensaver to black.
This PR gives the option to turn off the TV even if the Playback is paused. Also I added a configurable delay after which the TV is really turned off when the Screensaver kicks in.
The motivation here is the same. I want to turn the TV black as fast as possible to avoid burn-in which would be after 1min. But when I would use the option to turn of the TV it would turn off after every minute which can be quite annoying if you just go grab yourself a beer out the fridge. So I added a delay setting.
Currently in my settings it works like this: After 1min Screensaver is turned on (black). My delay is set to 5min. After 5min the TV is turned off.

By default everything works as it did before.

This PR will required a rebase of the patches in CoreELEC cause it touches peripherals.xml.