### PR TITLE
WinSystemAmlogic: don't generate OnLostDisplay

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -200,14 +200,6 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
     m_dispResetTimer.Set(delay * 100);
   }
 
-  {
-    CSingleLock lock(m_resourceSection);
-    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
-    {
-      (*i)->OnLostDisplay();
-    }
-  }
-
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 


### PR DESCRIPTION
Device: LePotato S905X (and other GXL). Issue: with automatic refreshrate switching on, playing Netflix or any other InputStream Adaptive video with `amcodec` turned off causes flickering screen with no picture and lots of `OutputPicture - timeout waiting for buffer` in the log. With debug logging turned on, the issue does not occur.

After many trials, the change that fixes the issue is removing generation of `OnLostDisplay` from `WinSystemAmlogic`.

So far I have not noticed negative effect of that modification but it needs to be tested on newer devices with S905X2/3, S922 etc.

Steps to reproduce:
1. Take S905X device.
2. Install IA, widevine.
3. Turn on automatic refreshrate, turn off amcodec.
4. Play [bitmovin.strm.txt](https://github.com/CoreELEC/xbmc/files/6413314/bitmovin.strm.txt) (remove `txt` from extension).

