### PR TITLE
InputStreamAddon, DVDDemuxClient: assume progressive streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -465,6 +465,8 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
       streamVideo->fAspect = source->fAspect;
       streamVideo->iFpsScale = source->iFpsScale;
       streamVideo->iFpsRate = source->iFpsRate;
+      streamVideo->bUnknownIP = false;
+      streamVideo->bInterlaced = false;
     }
     streamVideo->iBitRate = source->iBitRate;
     if (source->ExtraSize > 0 && source->ExtraData)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -419,6 +419,8 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
     videoStream->iHeight = stream->m_Height;
     videoStream->fAspect = stream->m_Aspect;
     videoStream->iBitRate = stream->m_BitRate;
+    videoStream->bUnknownIP = false;
+    videoStream->bInterlaced = false;
     videoStream->profile = ConvertVideoCodecProfile(stream->m_codecProfile);
 
     /*! Added on API version 2.0.8 */


### PR DESCRIPTION
CE's Kodi sets these to true by default, ffmpeg demuxer sets them accordingly but addons cannot do that. Most of streams from addons are progressive, set these to progressive by default.