### PR TITLE
VideoPlayerVideo: Fix interlace/progressive info in PlayerDebug

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2196,7 +2196,6 @@ float CAMLCodec::GetTimeSize()
 
 CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
 {
-  std::string vfmt;
   struct vdec_info vi;
 
   if (!m_opened)
@@ -2233,9 +2232,6 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
     return CDVDVideoCodec::VC_EOF;
   else if (timesize < 1.0)
     return CDVDVideoCodec::VC_BUFFER;
-
-  if (!SysfsUtils::GetString("/sys/class/deinterlace/di0/frame_format", vfmt) && (vfmt.size() > 4))
-    m_processInfo.SetVideoInterlaced(vfmt.compare("progressive"));
 
   return CDVDVideoCodec::VC_NONE;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -18,6 +18,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
+#include "utils/SysfsUtils.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
@@ -332,6 +333,9 @@ void CVideoPlayerVideo::Process()
   int iDropDirective;
   bool onlyPrioMsgs = false;
 
+  std::string vfmt;
+  int vfmtCheckCount = 0;
+
   m_videoStats.Start();
   m_droppingStats.Reset();
   m_iDroppedFrames = 0;
@@ -371,6 +375,11 @@ void CVideoPlayerVideo::Process()
           m_picture.videoBuffer)
       {
         m_outputSate = OutputPicture(&m_picture);
+        if (m_processInfo.IsVideoHwDecoder())
+        {
+          vfmtCheckCount = 16;
+          CLog::Log(LOGDEBUG, "CVideoPlayerVideo - OUTPUT_AGAIN - vfmt, interlace should be checked.");
+        }
         if (m_outputSate == OUTPUT_AGAIN)
         {
           onlyPrioMsgs = true;
@@ -441,6 +450,11 @@ void CVideoPlayerVideo::Process()
       m_renderManager.ShowVideo(true);
 
       CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::GENERAL_RESYNC(%f)", pts);
+      if (m_processInfo.IsVideoHwDecoder())
+      {
+        vfmtCheckCount = 16;
+        CLog::Log(LOGDEBUG, "CVideoPlayerVideo - OUTPUT_AGAIN - vfmt, interlace should be checked.");
+      }
     }
     else if (pMsg->IsType(CDVDMsg::VIDEO_SET_ASPECT))
     {
@@ -601,6 +615,13 @@ void CVideoPlayerVideo::Process()
         if (ProcessDecoderOutput(frametime, pts))
         {
           onlyPrioMsgs = true;
+        }
+
+        if (vfmtCheckCount > 0 && --vfmtCheckCount % 5 == 0)
+        {
+          if (!SysfsUtils::GetString("/sys/class/deinterlace/di0/frame_format", vfmt) && (vfmt.size() > 4))
+            m_processInfo.SetVideoInterlaced(vfmt.compare("progressive"));
+          CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::DEMUXER_PACKET - checking interlace vfmt: %s", vfmt);
         }
       }
       else


### PR DESCRIPTION
It takes some time for correct HW di frame_format value to be in file.
Now interlace flag checked only 4 times with some period on stream start or after some stream change.
Contains revert for 2 commits:
https://github.com/CoreELEC/xbmc/commit/e6f7a0d214f05dbf183fceaea662b851316635b0
https://github.com/CoreELEC/xbmc/commit/a655c4fc29700d384cba9ce277a922d50517ad41