### PR TITLE
Revert "WinSystemAmlogic: don't generate OnLostDisplay"

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -200,6 +200,14 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
     m_dispResetTimer.Set(delay * 100);
   }
 
+  {
+    CSingleLock lock(m_resourceSection);
+    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
+    {
+      (*i)->OnLostDisplay();
+    }
+  }
+
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 


### PR DESCRIPTION
This reverts commit 2eb98bb62e7d0ffac9dbd9babab106b97ce10b3a.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR fully broke "Delay after change of refresh rate" functionality