### PR TITLE
AMLCodec: reset m_last_pts on Reset() (e.g. seek)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2278,6 +2278,7 @@ void CAMLCodec::Reset()
 
   // reset some interal vars
   m_cur_pts = DVD_NOPTS_VALUE;
+  m_last_pts = DVD_NOPTS_VALUE;
   m_state = 0;
   m_frameSizes.clear();
   m_frameSizeSum = 0;


### PR DESCRIPTION
Add `m_last_pts` reset on seek. This variable is used in `iDuration` calulcation and may get very big if we seek backwards.

Seems to improve seeking live streams played with ISA.