### PR TITLE
AMLCodec: fix memory leak created by av_grow_packet()

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -591,7 +591,7 @@ void am_packet_release(am_packet_t *pkt)
       free(pkt->hdr->data), pkt->hdr->data = NULL;
     free(pkt->hdr), pkt->hdr = NULL;
   }
-
+  av_buffer_unref(&pkt->avpkt.buf);
   pkt->codec = NULL;
 }
 


### PR DESCRIPTION
av_grow_packet() allocates a dynamic buffer which must be freed when we close the decoder
