### PR TITLE
Enhanced VC-1 Acceleration Options

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22961,6 +22961,11 @@ msgctxt "#39003"
 msgid "Accelerate h264"
 msgstr ""
 
+#: system/settings/settings.xml
+msgctxt "#39004"
+msgid "Accelerate VC1"
+msgstr ""
+
 #. Description of category "Library" with label #14202
 #: system/settings/settings.xml
 msgctxt "#39004"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22947,6 +22947,11 @@ msgid "HD and up"
 msgstr ""
 
 #: system/settings/settings.xml
+msgctxt "#39037"
+msgid "Interlaced only"
+msgstr ""
+
+#: system/settings/settings.xml
 msgctxt "#39001"
 msgid "Accelerate MPEG2"
 msgstr ""
@@ -22962,7 +22967,7 @@ msgid "Accelerate h264"
 msgstr ""
 
 #: system/settings/settings.xml
-msgctxt "#39004"
+msgctxt "#39036"
 msgid "Accelerate VC1"
 msgstr ""
 

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22948,7 +22948,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#39037"
-msgid "Interlaced only"
+msgid "Exclude 24p"
 msgstr ""
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -129,6 +129,7 @@
           <constraints>
             <options>
               <option label="20420">9999</option>   <!-- Never -->
+              <option label="20423">9998</option>   <!-- Interlaced -->
               <option label="39000">800</option>  <!-- HD -->
               <option label="20422">0</option>  <!-- Always -->
             </options>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -189,13 +189,14 @@
           <control type="spinner" format="string" />
           <control type="edit" format="integer" />
         </setting>
-        <setting id="videoplayer.useamcodecvc1" type="integer" label="39004">
+        <setting id="videoplayer.useamcodecvc1" type="integer" label="39036">
           <requirement>HAVE_AMCODEC</requirement>
           <level>2</level>
           <default>0</default>
           <constraints>
             <options>
               <option label="20420">9999</option>   <!-- Never -->
+              <option label="39037">9998</option>  <!-- Interlaced Only -->
               <option label="39000">800</option>  <!-- HD -->
               <option label="20422">0</option>  <!-- Always -->
             </options>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -129,7 +129,7 @@
           <constraints>
             <options>
               <option label="20420">9999</option>   <!-- Never -->
-              <option label="20423">9998</option>   <!-- Interlaced -->
+              <option label="20423">9998</option>   <!-- Exclude 24p -->
               <option label="39000">800</option>  <!-- HD -->
               <option label="20422">0</option>  <!-- Always -->
             </options>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -188,6 +188,28 @@
           <control type="spinner" format="string" />
           <control type="edit" format="integer" />
         </setting>
+        <setting id="videoplayer.useamcodecvc1" type="integer" label="39004">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="20420">9999</option>   <!-- Never -->
+              <option label="39000">800</option>  <!-- HD -->
+              <option label="20422">0</option>  <!-- Always -->
+            </options>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useamcodec" operator="is">true</condition> <!-- USE AMCODEC -->
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+          <control type="edit" format="integer" />
+        </setting>
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -129,7 +129,6 @@
           <constraints>
             <options>
               <option label="20420">9999</option>   <!-- Never -->
-              <option label="20423">9998</option>   <!-- Exclude 24p -->
               <option label="39000">800</option>  <!-- HD -->
               <option label="20422">0</option>  <!-- Always -->
             </options>
@@ -196,7 +195,7 @@
           <constraints>
             <options>
               <option label="20420">9999</option>   <!-- Never -->
-              <option label="39037">9998</option>  <!-- Interlaced Only -->
+              <option label="39037">9998</option>  <!-- Exclude 24p -->
               <option label="39000">800</option>  <!-- HD -->
               <option label="20422">0</option>  <!-- Always -->
             </options>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1816,8 +1816,6 @@ CAMLCodec::CAMLCodec(CProcessInfo &processInfo)
   , m_bufferIndex(-1)
   , m_state(0)
   , m_processInfo(processInfo)
-  , m_is_dv_p7_mel(false)
-  , m_dolby_vision_wait_delay(0)
 {
   am_private = new am_private_t;
   memset(am_private, 0, sizeof(am_private_t));
@@ -1854,7 +1852,7 @@ int CAMLCodec::GetAmlDuration() const
   return am_private ? (am_private->video_rate * PTS_FREQ) / UNIT_FREQ : 0;
 };
 
-bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
+bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
 {
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_drain = false;
@@ -1981,8 +1979,8 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hdr type: {}", hdrType);
 
   if (hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
-    CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DOVI: version {:d}.{:d}, profile {:d}",
-      hints.dovi.dv_version_major, hints.dovi.dv_version_minor, hints.dovi.dv_profile);
+    CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DOVI: version {:d}.{:d}, profile {:d}, el type {:d}",
+      hints.dovi.dv_version_major, hints.dovi.dv_version_minor, hints.dovi.dv_profile, dovi_el_type);
 
   m_processInfo.SetVideoDAR(hints.aspect);
   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder decoder timeout: {:d}s",
@@ -2032,19 +2030,15 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     }
 
     am_private->gcodec.dv_enable = 1;
-    if (!m_is_dv_p7_mel && (hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7) && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+    if ((hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7) && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI) == 0)
     {
-      CSysfsPath amdolby_vision_debug{"/sys/class/amdolby_vision/debug"};
-      if (amdolby_vision_debug.Exists())
-        amdolby_vision_debug.Set("enable_fel 1");
-      am_private->gcodec.dec_mode  = STREAM_TYPE_STREAM;
-
-      CSysfsPath dolby_vision_wait_delay{"/sys/module/amdolby_vision/parameters/dolby_vision_wait_delay"};
-      if (dolby_vision_wait_delay.Exists())
+      if (dovi_el_type != ELType::TYPE_MEL) // use stream path if not MEL
       {
-        m_dolby_vision_wait_delay = dolby_vision_wait_delay.Get<unsigned int>().value();
-        CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DoVi P{:d} MEL detection frame delay got set to {:d} frames", hints.dovi.dv_profile, m_dolby_vision_wait_delay);
+        CSysfsPath amdolby_vision_debug{"/sys/class/amdolby_vision/debug"};
+        if (amdolby_vision_debug.Exists())
+          amdolby_vision_debug.Set("enable_fel 1");
+        am_private->gcodec.dec_mode  = STREAM_TYPE_STREAM;
       }
     }
   }
@@ -2663,22 +2657,6 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
 
     CLog::Log(LOGDEBUG, LOGVIDEO, "CAMLCodec::GetPicture: index: {:d}, pts: {:.3f}, dur:{:.3f}ms ar:{:.2f} elf:{:d}ms",
       m_bufferIndex, pVideoPicture->pts / DVD_TIME_BASE, pVideoPicture->iDuration / 1000, m_hints.aspect, elapsed_since_last_frame.count());
-
-    if (m_dolby_vision_wait_delay > 0 && !m_is_dv_p7_mel)
-    {
-      m_dolby_vision_wait_delay--;
-      CSysfsPath is_mel{"/sys/module/amdolby_vision/parameters/is_mel"};
-      if (is_mel.Exists())
-      {
-        if (is_mel.Get<char>().value() == 'Y')
-        {
-          CLog::Log(LOGDEBUG, LOGVIDEO, "CAMLCodec::GetPicture: DoVi P{:d} MEL content detected, request to reopen decoder",
-            m_hints.dovi.dv_profile);
-          m_is_dv_p7_mel = true;
-          return CDVDVideoCodec::VC_REOPEN;
-        }
-      }
-    }
 
     return CDVDVideoCodec::VC_PICTURE;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -13,6 +13,7 @@
 #include "cores/IPlayer.h"
 #include "windowing/Resolution.h"
 #include "rendering/RenderSystem.h"
+#include "utils/BitstreamConverter.h"
 #include "utils/Geometry.h"
 
 #include <deque>
@@ -62,7 +63,7 @@ public:
   CAMLCodec(CProcessInfo &processInfo);
   virtual ~CAMLCodec();
 
-  bool          OpenDecoder(CDVDStreamInfo &hints);
+  bool          OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type);
   bool          Enable_vadj1();
   void          CloseDecoder();
   void          Reset();
@@ -109,8 +110,6 @@ private:
   uint64_t         m_cur_pts;
   uint64_t         m_last_pts;
   uint32_t         m_bufferIndex;
-  bool             m_is_dv_p7_mel;
-  uint32_t         m_dolby_vision_wait_delay;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -138,4 +138,6 @@ private:
   CProcessInfo &m_processInfo;
   int m_decoder_timeout;
   std::chrono::time_point<std::chrono::system_clock> m_tp_last_frame;
+
+  bool m_buffer_level_ready;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -230,8 +230,13 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_VC1:
       if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1))
       {
-        CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
-        goto FAIL;
+        if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)!=9998) {
+          CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+          goto FAIL;
+        } else if (m_hints.fpsrate!=29.97) {
+            CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+            goto FAIL;
+        }
       }
       m_pFormatName = "am-vc1";
       break;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -230,10 +230,12 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_VC1:
       if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1))
       {
+        int partial_fpsrate = m_hints.fpsrate * 100;
+        int interlaced_fps = 60000/1001 * 100;
         if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)!=9998) {
           CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
           goto FAIL;
-        } else if (m_hints.fpsrate!=(60000/1001)) {
+        } else if (partial_fpsrate!=interlaced_fps) {
             CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
             goto FAIL;
         }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -15,7 +15,6 @@
 #include "AMLCodec.h"
 #include "ServiceBroker.h"
 #include "utils/AMLUtils.h"
-#include "utils/BitstreamConverter.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -381,6 +380,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
 
   uint8_t *pData(packet.pData);
   int iSize(packet.iSize);
+  enum ELType dovi_el_type = ELType::TYPE_NONE;
 
   if (pData)
   {
@@ -396,6 +396,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       }
       pData = m_bitstream->GetConvertBuffer();
       iSize = m_bitstream->GetConvertSize();
+      dovi_el_type = m_bitstream->GetDoviElType();
     }
     else if (!m_has_keyframe && m_bitparser)
     {
@@ -415,7 +416,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
         m_hints.ptsinvalid = true;
 
       CLog::Log(LOGINFO, "{}::{} Open decoder: fps:{:d}/{:d}", __MODULE_NAME__, __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
-      if (m_Codec && !m_Codec->OpenDecoder(m_hints))
+      if (m_Codec && !m_Codec->OpenDecoder(m_hints, dovi_el_type))
         CLog::Log(LOGERROR, "{}: Failed to open Amlogic Codec", __MODULE_NAME__);
 
       m_videoBufferPool = std::shared_ptr<CAMLVideoBufferPool>(new CAMLVideoBufferPool());
@@ -436,12 +437,6 @@ void CDVDVideoCodecAmlogic::Reset(void)
     m_bitstream->ResetStartDecode();
 }
 
-void CDVDVideoCodecAmlogic::Reopen(void)
-{
-  if (m_Codec && !m_Codec->OpenDecoder(m_hints))
-    CLog::Log(LOGERROR, "{}: Failed to reopen Amlogic Codec", __MODULE_NAME__);
-}
-
 CDVDVideoCodec::VCReturn CDVDVideoCodecAmlogic::GetPicture(VideoPicture* pVideoPicture)
 {
   if (!m_Codec)
@@ -449,11 +444,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAmlogic::GetPicture(VideoPicture* pVideoP
 
   VCReturn retVal = m_Codec->GetPicture(&m_videobuffer);
 
-  if (retVal == VC_REOPEN)
-  {
-    m_Codec->CloseDecoder();
-  }
-  else if (retVal == VC_PICTURE)
+  if (retVal == VC_PICTURE)
   {
     pVideoPicture->SetParams(m_videobuffer);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -233,7 +233,7 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
         if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)!=9998) {
           CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
           goto FAIL;
-        } else if (m_hints.fpsrate!=29.97) {
+        } else if (m_hints.fpsrate!=(60000/1001)) {
             CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
             goto FAIL;
         }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -228,6 +228,11 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       CLog::Log(LOGDEBUG, "{}::{} - amcodec does not support RMVB", __MODULE_NAME__, __FUNCTION__);
       goto FAIL;
     case AV_CODEC_ID_VC1:
+      if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1))
+      {
+        CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+        goto FAIL;
+      }
       m_pFormatName = "am-vc1";
       break;
     case AV_CODEC_ID_WMV3:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -232,7 +232,7 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
         if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)!=9998) {
           CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
           goto FAIL;
-        } else if (m_hints.fpsrate < 30000) {
+        } else if (m_hints.fpsrate <= 24000) {
             CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
             goto FAIL;
         }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -228,14 +228,11 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       CLog::Log(LOGDEBUG, "{}::{} - amcodec does not support RMVB", __MODULE_NAME__, __FUNCTION__);
       goto FAIL;
     case AV_CODEC_ID_VC1:
-      if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1))
-      {
-        int partial_fpsrate = m_hints.fpsrate * 100;
-        int interlaced_fps = 60000/1001 * 100;
+      if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)) {
         if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)!=9998) {
           CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
           goto FAIL;
-        } else if (partial_fpsrate!=interlaced_fps) {
+        } else if (m_hints.fpsrate < 30000) {
             CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
             goto FAIL;
         }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -12,6 +12,7 @@
 #include "DVDStreamInfo.h"
 #include "threads/CriticalSection.h"
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+#include "utils/BitstreamConverter.h"
 
 #include <set>
 #include <atomic>
@@ -70,7 +71,6 @@ public:
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
   virtual bool AddData(const DemuxPacket &packet) override;
   virtual void Reset() override;
-  virtual void Reopen() override;
   virtual VCReturn GetPicture(VideoPicture* pVideoPicture) override;
   virtual void SetSpeed(int iSpeed) override;
   virtual void SetCodecControl(int flags) override;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -307,7 +307,7 @@ void CDVDMessageQueue::WaitUntilEmpty()
   }
 }
 
-int CDVDMessageQueue::GetLevel() const
+int CDVDMessageQueue::GetLevel(bool data_level) const
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
@@ -316,9 +316,9 @@ int CDVDMessageQueue::GetLevel() const
   if (m_iDataSize == 0)
     return 0;
 
-  if (IsDataBased())
+  if (IsDataBased() || data_level)
   {
-    return std::min(100, 100 * m_iDataSize / m_iMaxDataSize);
+    return std::min((uint64_t)100, 100 * m_iDataSize / m_iMaxDataSize);
   }
 
   int level = std::min(100.0, ceil(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -80,8 +80,8 @@ public:
   void WaitUntilEmpty();
 
   // non messagequeue related functions
-  bool IsFull() const { return GetLevel() == 100; }
-  int GetLevel() const;
+  bool IsFull() const { return GetLevel(true) == 100; }
+  int GetLevel(bool data_level = false) const;
 
   void SetMaxDataSize(int iMaxDataSize) { m_iMaxDataSize = iMaxDataSize; }
   void SetMaxTimeSize(double sec) { m_TimeSize  = 1.0 / std::max(1.0, sec); }
@@ -102,15 +102,14 @@ private:
   bool m_bInitialized;
   bool m_drain = false;
 
-  int m_iDataSize;
+  uint64_t m_iDataSize;
   double m_TimeFront;
   double m_TimeBack;
   double m_TimeSize;
 
-  int m_iMaxDataSize;
+  uint64_t m_iMaxDataSize;
   std::string m_owner;
 
   std::list<DVDMessageListItem> m_messages;
   std::list<DVDMessageListItem> m_prioMessages;
 };
-

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -21,6 +21,15 @@
 #define VideoPlayer_RDS      5
 #define VideoPlayer_ID3 6
 
+#define SIZE_1K              (int)1024
+#define SIZE_1M              (int)(SIZE_1K * 1024)
+
+#define LvLVideoMAX          (int)(200 * SIZE_1M)
+#define LvLVideoMIN          (int)(32 * SIZE_1M)
+
+#define LvLAudioMAX          (int)(32 * SIZE_1M)
+#define LvLAudioMIN          (int)(4 * SIZE_1M)
+
 class CDVDMsg;
 class CDVDStreamInfo;
 class CProcessInfo;
@@ -96,6 +105,10 @@ public:
   virtual int GetVideoBitrate() = 0;
   virtual void SetSpeed(int iSpeed) = 0;
   virtual bool IsEOS() { return false; }
+
+  virtual int  GetDataLevel() const = 0;
+  virtual void SetMaxDataSize(int iMaxDataSize) {}
+  virtual int GetMaxDataSize() const = 0;
 };
 
 class CDVDAudioCodec;
@@ -123,4 +136,8 @@ public:
   virtual bool IsPassthrough() const = 0;
   virtual float GetDynamicRangeAmplification() const = 0;
   virtual bool IsEOS() { return false; }
+
+  virtual int  GetDataLevel() const = 0;
+  virtual void SetMaxDataSize(int iMaxDataSize) {}
+  virtual int GetMaxDataSize() const = 0;
 };

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DVDClock.h"
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
 
 #include <string>
 #include <utility>
@@ -109,6 +110,7 @@ public:
   virtual int  GetDataLevel() const = 0;
   virtual void SetMaxDataSize(int iMaxDataSize) {}
   virtual int GetMaxDataSize() const = 0;
+  virtual double GetLastPTS() const { return DVD_NOPTS_VALUE; }
 };
 
 class CDVDAudioCodec;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1106,6 +1106,109 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
   return false;
 }
 
+void CVideoPlayer::HandleDynmaicBufferLevel()
+{
+  int lvlv = m_VideoPlayerVideo->GetDataLevel();
+  int lvla = m_VideoPlayerAudio->GetDataLevel();
+  int lvlvcmax = m_VideoPlayerVideo->GetMaxDataSize();
+  int lvlacmax = m_VideoPlayerAudio->GetMaxDataSize();
+  int lvlvcnew = lvlvcmax;
+  int lvlacnew = lvlacmax;
+
+  int lvldif = std::abs(lvlv - lvla);
+  bool lvlfull(std::max(lvlv, lvla) > 99);
+
+  int lvstep = 4 * SIZE_1M;
+  int lastep = 500 * SIZE_1K;
+
+  // one buffer is > 99% and difference between them is > 15%
+  // increase the full buffer to lift up the other
+  if (lvlfull && lvldif > 15 && lvlv > 0 && lvla > 0)
+  {
+    // video buffer is > 99%
+    if (lvlv > 99)
+    {
+      // video buffer still can be increased?
+      if (lvlvcmax + lvstep <= LvLVideoMAX)
+        lvlvcnew = lvlvcmax + lvstep;
+    }
+    // audio buffer is > 99%
+    else if (lvla > 99)
+    {
+      // audio buffer still can be increased?
+      if (lvlacmax + lastep <= LvLAudioMAX)
+        lvlacnew = lvlacmax + lastep;
+    }
+  }
+  // both buffer are > 99%
+  // increase both buffer
+  else if ((lvlv > 99) && (lvla > 99))
+  {
+    // video buffer still can be increased?
+    if (lvlvcmax + lvstep <= LvLVideoMAX)
+      lvlvcnew = lvlvcmax + lvstep;
+
+    // audio buffer still can be increased?
+    if (lvlacmax + lastep <= LvLAudioMAX)
+      lvlacnew = lvlacmax + lastep;
+  }
+  // both buffer are < 99% and difference is < 2%
+  // both buffer are < 99% and the level of both is < 85%
+  else if (!lvlfull && (lvldif < 2 || (100 - lvlv > 15 && 100 - lvla > 15)))
+  {
+    // left free level of video buffer > one level video step in %
+    if ((100 - lvlv) > (100 / lvlvcmax * lvstep))
+    {
+      // video buffer still can be increased?
+      if (lvlvcmax - lvstep >= LvLVideoMIN)
+        lvlvcnew = lvlvcmax - lvstep;
+    }
+
+    // left free level of audio buffer > one level audio step in %
+    if ((100 - lvla) > (100 / lvlacmax * lastep))
+    {
+      // audio buffer still can be increased?
+      if (lvlacmax - lastep >= LvLAudioMIN)
+        lvlacnew = lvlacmax - lastep;
+    }
+  }
+
+  // video buffer level is < 5% and current video buffer limit is > minimal video buffer level
+  if (lvlv < 5 && lvlvcmax > LvLVideoMIN)
+  {
+    if ((100 - lvlv) > (100 / lvlvcmax * lvstep))
+    {
+      if (lvlvcmax - lvstep >= LvLVideoMIN)
+        lvlvcnew = lvlvcmax - lvstep;
+    }
+  }
+
+  // audio buffer level is < 5% and current audio buffer limit is > minimal audio buffer level
+  if (lvla < 5 && lvlacmax > LvLAudioMIN)
+  {
+    if ((100 - lvla) > (100 / lvlacmax * lastep))
+    {
+      if (lvlacmax - lastep >= LvLAudioMIN)
+        lvlacnew = lvlacmax - lastep;
+    }
+  }
+
+  // apply new buffer level limits to message queues
+  if (lvlvcnew != lvlvcmax)
+  {
+    CLog::Log(LOGDEBUG, LOGAVTIMING, "CVideoPlayer::{} {} video buffer to: {:d}MB, level video: {:d}%, level audio: {:d}%", __FUNCTION__,
+      (lvlvcnew > lvlvcmax) ? "increased" : "decreased", lvlvcnew / SIZE_1M, lvlv, lvla);
+    m_VideoPlayerVideo->SetMaxDataSize(lvlvcnew);
+  }
+
+  if (lvlacnew != lvlacmax)
+  {
+    CLog::Log(LOGDEBUG, LOGAVTIMING, "CVideoPlayer::{} {} audio buffer to: {:d}MB, level video: {:d}%, level audio: {:d}%", __FUNCTION__,
+      (lvlacnew > lvlacmax) ? "increased" : "decreased", lvlacnew / SIZE_1M, lvlv, lvla);
+    m_VideoPlayerAudio->SetMaxDataSize(lvlacnew);
+  }
+}
+
 bool CVideoPlayer::IsValidStream(const CCurrentStream& stream)
 {
   if(stream.id<0)
@@ -1425,6 +1528,8 @@ void CVideoPlayer::Process()
 
     // update player state
     UpdatePlayState(200);
+
+    HandleDynmaicBufferLevel();
 
     // make sure we run subtitle process here
     m_VideoPlayerSubtitle->Process(m_clock.GetClock() + m_State.time_offset - m_VideoPlayerVideo->GetSubtitleDelay(), m_State.time_offset);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -126,6 +126,7 @@ public:
   const int player;
   // stuff to handle starting after seek
   double startpts;
+  double lastpts;
   double lastdts;
 
   enum

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -439,6 +439,7 @@ protected:
   void SendPlayerMessage(std::shared_ptr<CDVDMsg> pMsg, unsigned int target);
 
   bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
+  void HandleDynmaicBufferLevel();
   bool IsValidStream(const CCurrentStream& stream);
   bool IsBetterStream(const CCurrentStream& current, CDemuxStream* stream);
   void CheckBetterStream(CCurrentStream& current, CDemuxStream* stream);

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -61,7 +61,7 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_prevskipped = false;
   m_maxspeedadjust = 0.0;
 
-  m_messageQueue.SetMaxDataSize(32 * 1024 * 1024);
+  m_messageQueue.SetMaxDataSize(LvLAudioMIN);
   m_messageQueue.SetMaxTimeSize(8.0);
   m_disconAdjustTimeMs = processInfo.GetMaxPassthroughOffSyncDuration();
 }
@@ -201,8 +201,10 @@ void CVideoPlayerAudio::OnStartup()
 void CVideoPlayerAudio::UpdatePlayerInfo()
 {
   std::ostringstream s;
-  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99,m_messageQueue.GetLevel(true)) << "%)";
-  s << ", Kb/s:" << std::fixed << std::setprecision(2) << m_audioStats.GetBitrate() / 1024.0;
+  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "% ("
+    << std::setw(2) << std::min(99,m_messageQueue.GetLevel(true)) << "%, "
+    << std::setw(2) << m_messageQueue.GetMaxDataSize() / SIZE_1M << "MB)";
+  s << ", Kb/s:" << std::fixed << std::setprecision(2) << m_audioStats.GetBitrate() / SIZE_1K;
   s << ", ac:"   << m_processInfo.GetAudioDecoderName().c_str();
   if (!m_info.passthrough)
     s << ", chan:" << m_processInfo.GetAudioChannels().c_str();

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -61,7 +61,7 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_prevskipped = false;
   m_maxspeedadjust = 0.0;
 
-  m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
+  m_messageQueue.SetMaxDataSize(32 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
   m_disconAdjustTimeMs = processInfo.GetMaxPassthroughOffSyncDuration();
 }
@@ -201,7 +201,7 @@ void CVideoPlayerAudio::OnStartup()
 void CVideoPlayerAudio::UpdatePlayerInfo()
 {
   std::ostringstream s;
-  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
+  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99,m_messageQueue.GetLevel(true)) << "%)";
   s << ", Kb/s:" << std::fixed << std::setprecision(2) << m_audioStats.GetBitrate() / 1024.0;
   s << ", ac:"   << m_processInfo.GetAudioDecoderName().c_str();
   if (!m_info.passthrough)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -65,6 +65,10 @@ public:
   bool IsStalled() const override { return m_stalled;  }
   bool IsPassthrough() const override;
 
+  int  GetDataLevel() const { return m_messageQueue.GetLevel(true); }
+  void SetMaxDataSize(int iMaxDataSize) { m_messageQueue.SetMaxDataSize(iMaxDataSize); }
+  int GetMaxDataSize() const { return m_messageQueue.GetMaxDataSize(); }
+
 protected:
 
   void OnStartup() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -342,16 +342,18 @@ void CVideoPlayerVideo::Process()
 
   std::string vfmt;
   int vfmtCheckCount = 0;
+  int timeoutCount = 0;
 
   m_videoStats.Start();
   m_droppingStats.Reset();
   m_iDroppedFrames = 0;
   m_rewindStalled = false;
   m_outputSate = OUTPUT_NORMAL;
+  m_last_pts = DVD_NOPTS_VALUE;
 
   while (!m_bStop)
   {
-    int iQueueTimeOut = (int)(m_stalled ? frametime : frametime * 10) / 1000;
+    int iQueueTimeOut = (int)(frametime) / 1000;
     int iPriority = 0;
 
     if (m_syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
@@ -380,6 +382,9 @@ void CVideoPlayerVideo::Process()
     }
     else if (ret == MSGQ_TIMEOUT)
     {
+      // increase timeout count
+      timeoutCount++;
+
       if (m_outputSate == OUTPUT_AGAIN &&
           m_picture.videoBuffer)
       {
@@ -402,13 +407,13 @@ void CVideoPlayerVideo::Process()
       {
         if (ProcessDecoderOutput(frametime, pts))
         {
-          onlyPrioMsgs = true;
+          timeoutCount = 0;
           continue;
         }
       }
 
       // if we only wanted priority messages, this isn't a stall
-      if (iPriority)
+      if (iPriority || timeoutCount < 10)
         continue;
 
       //Okey, start rendering at stream fps now instead, we are likely in a stillframe
@@ -429,6 +434,7 @@ void CVideoPlayerVideo::Process()
       }
 
       // Waiting timed out, output last picture
+      CLog::Log(LOGDEBUG, "CVideoPlayerVideo({:d}) - MSGQ_TIMEOUT", __LINE__);
       if (m_picture.videoBuffer)
       {
         m_picture.pts = pts;
@@ -986,6 +992,10 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
   int buffer = m_renderManager.WaitForBuffer(m_bAbortOutput, maxWaitTime);
   CLog::Log(LOGDEBUG,"CVideoPlayerVideo::{} - ttd:{:d}ms pts:{:.3f} Clock:{:.3f} Level:{:d}",
         __FUNCTION__, timeToDisplay.count(), pPicture->pts / DVD_TIME_BASE, static_cast<double>(iPlayingClock) / DVD_TIME_BASE, buffer);
+
+  // backup last output frame pts
+  m_last_pts = pPicture->pts;
+
   if (buffer < 0)
   {
     if (m_speed != DVD_PLAYSPEED_PAUSE)

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -1013,7 +1013,7 @@ std::string CVideoPlayerVideo::GetPlayerInfo()
   int width, height;
   m_processInfo.GetVideoDimensions(width, height);
   std::ostringstream s;
-  s << "vq:"   << std::setw(2) << std::min(99, m_processInfo.GetLevelVQ()) << "%";
+  s << "vq:"   << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true)) << "%)";
   s << ", Mb/s:" << std::fixed << std::setprecision(2) << (double)GetVideoBitrate() / (1024.0*1024.0);
   s << ", dc:"   << m_processInfo.GetVideoDecoderName().c_str();
   s << ", " << width << "x" << height << (m_processInfo.GetVideoInterlaced() ? "i" : "p") << " [" << std::setprecision(2) << m_processInfo.GetVideoDAR() << "]@" << std::fixed << std::setprecision(3) << m_processInfo.GetVideoFps() << ", deint:" << m_processInfo.GetVideoDeintMethod();

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -67,7 +67,8 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_iLateFrames = 0;
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
-  m_messageQueue.SetMaxDataSize(40 * 1024 * 1024);
+
+  m_messageQueue.SetMaxDataSize(LvLVideoMIN);
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_iDroppedFrames = 0;
@@ -1013,8 +1014,10 @@ std::string CVideoPlayerVideo::GetPlayerInfo()
   int width, height;
   m_processInfo.GetVideoDimensions(width, height);
   std::ostringstream s;
-  s << "vq:"   << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true)) << "%)";
-  s << ", Mb/s:" << std::fixed << std::setprecision(2) << (double)GetVideoBitrate() / (1024.0*1024.0);
+  s << "vq:"   << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% ("
+    << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true)) << "%, "
+    << std::setw(3) << m_messageQueue.GetMaxDataSize() / SIZE_1M << "MB)";
+  s << ", Mb/s:" << std::fixed << std::setprecision(2) << (double)GetVideoBitrate() / (double)SIZE_1M;
   s << ", dc:"   << m_processInfo.GetVideoDecoderName().c_str();
   s << ", " << width << "x" << height << (m_processInfo.GetVideoInterlaced() ? "i" : "p") << " [" << std::setprecision(2) << m_processInfo.GetVideoDAR() << "]@" << std::fixed << std::setprecision(3) << m_processInfo.GetVideoFps() << ", deint:" << m_processInfo.GetVideoDeintMethod();
   s << ", drop:" << m_iDroppedFrames;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -76,6 +76,7 @@ public:
   int  GetDataLevel() const { return m_messageQueue.GetLevel(true); }
   void SetMaxDataSize(int iMaxDataSize) { m_messageQueue.SetMaxDataSize(iMaxDataSize); }
   int GetMaxDataSize() const { return m_messageQueue.GetMaxDataSize(); }
+  double GetLastPTS() const { return m_last_pts; }
 
   // classes
   CDVDOverlayContainer* m_pOverlayContainer;
@@ -146,4 +147,6 @@ protected:
   VideoPicture m_picture;
 
   EOutputState m_outputSate;
+
+  double m_last_pts;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -73,6 +73,10 @@ public:
   int GetVideoBitrate() override;
   void SetSpeed(int iSpeed) override;
 
+  int  GetDataLevel() const { return m_messageQueue.GetLevel(true); }
+  void SetMaxDataSize(int iMaxDataSize) { m_messageQueue.SetMaxDataSize(iMaxDataSize); }
+  int GetMaxDataSize() const { return m_messageQueue.GetMaxDataSize(); }
+
   // classes
   CDVDOverlayContainer* m_pOverlayContainer;
   CDVDClock* m_pClock;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -144,6 +144,7 @@ constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODEC;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECMPEG2;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECMPEG4;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECH264;
+constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEVDPAU;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -119,6 +119,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG2 = "videoplayer.useamcodecmpeg2";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG4 = "videoplayer.useamcodecmpeg4";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECH264 = "videoplayer.useamcodech264";
+  static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECVC1 = "videoplayer.useamcodecvc1";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -77,6 +77,13 @@ typedef struct
   int frame_crop_bottom_offset;
 } sps_info_struct;
 
+enum ELType : int
+{
+  TYPE_NONE = 0,
+  TYPE_FEL,
+  TYPE_MEL
+};
+
 class CBitstreamParser
 {
 public:
@@ -105,6 +112,7 @@ public:
   void              ResetStartDecode(void);
   bool              CanStartDecode() const;
   void SetConvertDovi(int value) { m_convert_dovi = value; }
+  enum ELType GetDoviElType() const { return m_dovi_el_type; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
   static bool       h264_sequence_header(const uint8_t *data, const uint32_t size, h264_sequence *sequence);
@@ -152,4 +160,5 @@ protected:
   AVCodecID         m_codec;
   bool              m_start_decode;
   int               m_convert_dovi;
+  enum ELType       m_dovi_el_type;
 };


### PR DESCRIPTION
## Description
Provide enhanced user configurable options for VC-1 hardware acceleration, based on selection criteria

## Motivation and context
Currently there is no option to configure hardware acceleration for VC-1 playback. This presents issues in some instances such as hardware accelerated VC-1 decoding is subject to forced de-interlacing performed on even progressive content, resulting in considerable resolution loss for this content.  It appears hardware such as the S922X SoCs are powerful enough to perform software decoding of even 1080p24 content using the ffmpeg libraries for VC-1 playback.

Options are: Never, Always, HD and up, and Exclude 24p.  Defaults to Always (to retain existing behavior in lieu of user setting this option).

## How has this been tested?
Have tested multiple VC-1 content with all settings, including 24p, and interlaced content to ensure expected behavior.  As it appears no supported Amlogic hardware can perform sufficient and acceptable software decoding of interlaced VC-1, and therefore would still rely on hardware acceleration for these instances.

## What is the effect on users?
Provide more flexibility to the user so they can choose which options best suit their needs for VC-1 content playback, and provide the highest video quality and functionality.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
