### PR TITLE
Enhanced VC-1 Acceleration Options

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22947,6 +22947,11 @@ msgid "HD and up"
 msgstr ""
 
 #: system/settings/settings.xml
+msgctxt "#39037"
+msgid "Exclude 24p"
+msgstr ""
+
+#: system/settings/settings.xml
 msgctxt "#39001"
 msgid "Accelerate MPEG2"
 msgstr ""
@@ -22959,6 +22964,11 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39003"
 msgid "Accelerate h264"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39036"
+msgid "Accelerate VC1"
 msgstr ""
 
 #. Description of category "Library" with label #14202

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -188,6 +188,29 @@
           <control type="spinner" format="string" />
           <control type="edit" format="integer" />
         </setting>
+        <setting id="videoplayer.useamcodecvc1" type="integer" label="39036">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="20420">9999</option>   <!-- Never -->
+              <option label="39037">9998</option>  <!-- Exclude 24p -->
+              <option label="39000">800</option>  <!-- HD -->
+              <option label="20422">0</option>  <!-- Always -->
+            </options>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useamcodec" operator="is">true</condition> <!-- USE AMCODEC -->
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+          <control type="edit" format="integer" />
+        </setting>
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1816,8 +1816,6 @@ CAMLCodec::CAMLCodec(CProcessInfo &processInfo)
   , m_bufferIndex(-1)
   , m_state(0)
   , m_processInfo(processInfo)
-  , m_is_dv_p7_mel(false)
-  , m_dolby_vision_wait_delay(0)
 {
   am_private = new am_private_t;
   memset(am_private, 0, sizeof(am_private_t));
@@ -1854,7 +1852,7 @@ int CAMLCodec::GetAmlDuration() const
   return am_private ? (am_private->video_rate * PTS_FREQ) / UNIT_FREQ : 0;
 };
 
-bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
+bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
 {
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_drain = false;
@@ -1980,8 +1978,8 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hdr type: {}", hdrType);
 
   if (hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
-    CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DOVI: version {:d}.{:d}, profile {:d}",
-      hints.dovi.dv_version_major, hints.dovi.dv_version_minor, hints.dovi.dv_profile);
+    CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DOVI: version {:d}.{:d}, profile {:d}, el type {:d}",
+      hints.dovi.dv_version_major, hints.dovi.dv_version_minor, hints.dovi.dv_profile, dovi_el_type);
 
   m_processInfo.SetVideoDAR(hints.aspect);
   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder decoder timeout: {:d}s",
@@ -2031,19 +2029,15 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     }
 
     am_private->gcodec.dv_enable = 1;
-    if (!m_is_dv_p7_mel && (hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7) && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+    if ((hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7) && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI) == 0)
     {
-      CSysfsPath amdolby_vision_debug{"/sys/class/amdolby_vision/debug"};
-      if (amdolby_vision_debug.Exists())
-        amdolby_vision_debug.Set("enable_fel 1");
-      am_private->gcodec.dec_mode  = STREAM_TYPE_STREAM;
-
-      CSysfsPath dolby_vision_wait_delay{"/sys/module/amdolby_vision/parameters/dolby_vision_wait_delay"};
-      if (dolby_vision_wait_delay.Exists())
+      if (dovi_el_type != ELType::TYPE_MEL) // use stream path if not MEL
       {
-        m_dolby_vision_wait_delay = dolby_vision_wait_delay.Get<unsigned int>().value();
-        CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder DoVi P{:d} MEL detection frame delay got set to {:d} frames", hints.dovi.dv_profile, m_dolby_vision_wait_delay);
+        CSysfsPath amdolby_vision_debug{"/sys/class/amdolby_vision/debug"};
+        if (amdolby_vision_debug.Exists())
+          amdolby_vision_debug.Set("enable_fel 1");
+        am_private->gcodec.dec_mode  = STREAM_TYPE_STREAM;
       }
     }
   }
@@ -2659,22 +2653,6 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
 
     CLog::Log(LOGDEBUG, LOGVIDEO, "CAMLCodec::GetPicture: index: {:d}, pts: {:.3f}, dur:{:.3f}ms ar:{:.2f} elf:{:d}ms",
       m_bufferIndex, pVideoPicture->pts / DVD_TIME_BASE, pVideoPicture->iDuration / 1000, m_hints.aspect, elapsed_since_last_frame.count());
-
-    if (m_dolby_vision_wait_delay > 0 && !m_is_dv_p7_mel)
-    {
-      m_dolby_vision_wait_delay--;
-      CSysfsPath is_mel{"/sys/module/amdolby_vision/parameters/is_mel"};
-      if (is_mel.Exists())
-      {
-        if (is_mel.Get<char>().value() == 'Y')
-        {
-          CLog::Log(LOGDEBUG, LOGVIDEO, "CAMLCodec::GetPicture: DoVi P{:d} MEL content detected, request to reopen decoder",
-            m_hints.dovi.dv_profile);
-          m_is_dv_p7_mel = true;
-          return CDVDVideoCodec::VC_REOPEN;
-        }
-      }
-    }
 
     return CDVDVideoCodec::VC_PICTURE;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1867,6 +1867,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
   m_hints.pClock = hints.pClock;
   m_tp_last_frame = std::chrono::system_clock::now();
   m_decoder_timeout = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoDecoderTimeout;
+  m_buffer_level_ready = false;
 
   if (!OpenAmlVideo(hints))
   {
@@ -2394,6 +2395,12 @@ bool CAMLCodec::AddData(uint8_t *pData, size_t iSize, double dts, double pts)
   int data_len, free_len;
   int chunk_size = calc_chunk_size(iSize);
   float new_buffer_level = GetBufferLevel(chunk_size, data_len, free_len);
+  bool streambuffer(am_private->gcodec.dec_mode == STREAM_TYPE_STREAM);
+
+  if (!m_buffer_level_ready)
+    m_buffer_level_ready = (streambuffer ? (new_buffer_level > 90.0f) : (new_buffer_level > 5.0f));
+
+  m_minimum_buffer_level = (streambuffer ? 10.0f : 5.0f);
 
   if (!m_opened || !pData || free_len == 0 || new_buffer_level >= 100.0f)
   {
@@ -2628,13 +2635,17 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
   float buffer_level = GetBufferLevel();
   std::chrono::milliseconds elapsed_since_last_frame(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()
     - m_tp_last_frame).count());
+  bool streambuffer(am_private->gcodec.dec_mode == STREAM_TYPE_STREAM);
 
   if (!m_opened)
     return CDVDVideoCodec::VC_ERROR;
 
-  if ((!m_drain && buffer_level > 5.0f) && (ret = DequeueBuffer()) == 0)
+  if (!m_drain && m_buffer_level_ready && buffer_level > m_minimum_buffer_level && (ret = DequeueBuffer()) == 0)
   {
     pVideoPicture->iFlags = 0;
+
+    m_minimum_buffer_level = (streambuffer ? m_minimum_buffer_level : 0.0f);
+
     m_tp_last_frame = std::chrono::system_clock::now();
 
     if (m_last_pts == DVD_NOPTS_VALUE)
@@ -2658,7 +2669,7 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
   }
   else if (m_drain)
     return CDVDVideoCodec::VC_EOF;
-  else if (buffer_level > 10.0f)
+  else if (buffer_level > (streambuffer ? 100.0f : 10.0f))
     return CDVDVideoCodec::VC_NONE;
   else if (ret != EAGAIN || elapsed_since_last_frame > std::chrono::seconds(m_decoder_timeout))
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -137,4 +137,7 @@ private:
   CProcessInfo &m_processInfo;
   int m_decoder_timeout;
   std::chrono::time_point<std::chrono::system_clock> m_tp_last_frame;
+
+  bool            m_buffer_level_ready;
+  float           m_minimum_buffer_level;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -13,6 +13,7 @@
 #include "cores/IPlayer.h"
 #include "windowing/Resolution.h"
 #include "rendering/RenderSystem.h"
+#include "utils/BitstreamConverter.h"
 #include "utils/Geometry.h"
 
 #include <deque>
@@ -62,7 +63,7 @@ public:
   CAMLCodec(CProcessInfo &processInfo);
   virtual ~CAMLCodec();
 
-  bool          OpenDecoder(CDVDStreamInfo &hints);
+  bool          OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type);
   bool          Enable_vadj1();
   void          CloseDecoder();
   void          Reset();
@@ -109,8 +110,6 @@ private:
   uint64_t         m_cur_pts;
   uint64_t         m_last_pts;
   uint32_t         m_bufferIndex;
-  bool             m_is_dv_p7_mel;
-  uint32_t         m_dolby_vision_wait_delay;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -15,7 +15,6 @@
 #include "AMLCodec.h"
 #include "ServiceBroker.h"
 #include "utils/AMLUtils.h"
-#include "utils/BitstreamConverter.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -381,6 +380,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
 
   uint8_t *pData(packet.pData);
   int iSize(packet.iSize);
+  enum ELType dovi_el_type = ELType::TYPE_NONE;
 
   if (pData)
   {
@@ -396,6 +396,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       }
       pData = m_bitstream->GetConvertBuffer();
       iSize = m_bitstream->GetConvertSize();
+      dovi_el_type = m_bitstream->GetDoviElType();
     }
     else if (!m_has_keyframe && m_bitparser)
     {
@@ -415,7 +416,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
         m_hints.ptsinvalid = true;
 
       CLog::Log(LOGINFO, "{}::{} Open decoder: fps:{:d}/{:d}", __MODULE_NAME__, __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
-      if (m_Codec && !m_Codec->OpenDecoder(m_hints))
+      if (m_Codec && !m_Codec->OpenDecoder(m_hints, dovi_el_type))
         CLog::Log(LOGERROR, "{}: Failed to open Amlogic Codec", __MODULE_NAME__);
 
       m_videoBufferPool = std::shared_ptr<CAMLVideoBufferPool>(new CAMLVideoBufferPool());
@@ -436,12 +437,6 @@ void CDVDVideoCodecAmlogic::Reset(void)
     m_bitstream->ResetStartDecode();
 }
 
-void CDVDVideoCodecAmlogic::Reopen(void)
-{
-  if (m_Codec && !m_Codec->OpenDecoder(m_hints))
-    CLog::Log(LOGERROR, "{}: Failed to reopen Amlogic Codec", __MODULE_NAME__);
-}
-
 CDVDVideoCodec::VCReturn CDVDVideoCodecAmlogic::GetPicture(VideoPicture* pVideoPicture)
 {
   if (!m_Codec)
@@ -449,11 +444,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAmlogic::GetPicture(VideoPicture* pVideoP
 
   VCReturn retVal = m_Codec->GetPicture(&m_videobuffer);
 
-  if (retVal == VC_REOPEN)
-  {
-    m_Codec->CloseDecoder();
-  }
-  else if (retVal == VC_PICTURE)
+  if (retVal == VC_PICTURE)
   {
     pVideoPicture->SetParams(m_videobuffer);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -228,6 +228,18 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       CLog::Log(LOGDEBUG, "{}::{} - amcodec does not support RMVB", __MODULE_NAME__, __FUNCTION__);
       goto FAIL;
     case AV_CODEC_ID_VC1:
+      if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1)) 
+      {
+        if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1) != 9998) 
+	{
+          CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+          goto FAIL;
+        } else if (m_hints.fpsrate <= 24000) 
+	{
+            CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+            goto FAIL;
+        }
+      }
       m_pFormatName = "am-vc1";
       break;
     case AV_CODEC_ID_WMV3:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -12,6 +12,7 @@
 #include "DVDStreamInfo.h"
 #include "threads/CriticalSection.h"
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+#include "utils/BitstreamConverter.h"
 
 #include <set>
 #include <atomic>
@@ -70,7 +71,6 @@ public:
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
   virtual bool AddData(const DemuxPacket &packet) override;
   virtual void Reset() override;
-  virtual void Reopen() override;
   virtual VCReturn GetPicture(VideoPicture* pVideoPicture) override;
   virtual void SetSpeed(int iSpeed) override;
   virtual void SetCodecControl(int flags) override;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -307,7 +307,7 @@ void CDVDMessageQueue::WaitUntilEmpty()
   }
 }
 
-int CDVDMessageQueue::GetLevel() const
+int CDVDMessageQueue::GetLevel(bool data_level) const
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
@@ -316,9 +316,9 @@ int CDVDMessageQueue::GetLevel() const
   if (m_iDataSize == 0)
     return 0;
 
-  if (IsDataBased())
+  if (IsDataBased() || data_level)
   {
-    return std::min(100, 100 * m_iDataSize / m_iMaxDataSize);
+    return std::min((uint64_t)100, 100 * m_iDataSize / m_iMaxDataSize);
   }
 
   int level = std::min(100.0, ceil(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -80,8 +80,8 @@ public:
   void WaitUntilEmpty();
 
   // non messagequeue related functions
-  bool IsFull() const { return GetLevel() == 100; }
-  int GetLevel() const;
+  bool IsFull() const { return GetLevel(true) == 100; }
+  int GetLevel(bool data_level = false) const;
 
   void SetMaxDataSize(int iMaxDataSize) { m_iMaxDataSize = iMaxDataSize; }
   void SetMaxTimeSize(double sec) { m_TimeSize  = 1.0 / std::max(1.0, sec); }
@@ -102,15 +102,14 @@ private:
   bool m_bInitialized;
   bool m_drain = false;
 
-  int m_iDataSize;
+  uint64_t m_iDataSize;
   double m_TimeFront;
   double m_TimeBack;
   double m_TimeSize;
 
-  int m_iMaxDataSize;
+  uint64_t m_iMaxDataSize;
   std::string m_owner;
 
   std::list<DVDMessageListItem> m_messages;
   std::list<DVDMessageListItem> m_prioMessages;
 };
-

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -61,7 +61,7 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_prevskipped = false;
   m_maxspeedadjust = 0.0;
 
-  m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
+  m_messageQueue.SetMaxDataSize(32 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
   m_disconAdjustTimeMs = processInfo.GetMaxPassthroughOffSyncDuration();
 }
@@ -201,7 +201,7 @@ void CVideoPlayerAudio::OnStartup()
 void CVideoPlayerAudio::UpdatePlayerInfo()
 {
   std::ostringstream s;
-  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
+  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99,m_messageQueue.GetLevel(true)) << "%)";
   s << ", Kb/s:" << std::fixed << std::setprecision(2) << m_audioStats.GetBitrate() / 1024.0;
   s << ", ac:"   << m_processInfo.GetAudioDecoderName().c_str();
   if (!m_info.passthrough)

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -1013,7 +1013,7 @@ std::string CVideoPlayerVideo::GetPlayerInfo()
   int width, height;
   m_processInfo.GetVideoDimensions(width, height);
   std::ostringstream s;
-  s << "vq:"   << std::setw(2) << std::min(99, m_processInfo.GetLevelVQ()) << "%";
+  s << "vq:"   << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true)) << "%)";
   s << ", Mb/s:" << std::fixed << std::setprecision(2) << (double)GetVideoBitrate() / (1024.0*1024.0);
   s << ", dc:"   << m_processInfo.GetVideoDecoderName().c_str();
   s << ", " << width << "x" << height << (m_processInfo.GetVideoInterlaced() ? "i" : "p") << " [" << std::setprecision(2) << m_processInfo.GetVideoDAR() << "]@" << std::fixed << std::setprecision(3) << m_processInfo.GetVideoFps() << ", deint:" << m_processInfo.GetVideoDeintMethod();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -144,6 +144,7 @@ constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODEC;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECMPEG2;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECMPEG4;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECH264;
+constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE;
 constexpr const char* CSettings::SETTING_VIDEOPLAYER_USEVDPAU;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -119,6 +119,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG2 = "videoplayer.useamcodecmpeg2";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG4 = "videoplayer.useamcodecmpeg4";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECH264 = "videoplayer.useamcodech264";
+  static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECVC1 = "videoplayer.useamcodecvc1";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -77,6 +77,13 @@ typedef struct
   int frame_crop_bottom_offset;
 } sps_info_struct;
 
+enum ELType : int
+{
+  TYPE_NONE = 0,
+  TYPE_FEL,
+  TYPE_MEL
+};
+
 class CBitstreamParser
 {
 public:
@@ -105,6 +112,7 @@ public:
   void              ResetStartDecode(void);
   bool              CanStartDecode() const;
   void SetConvertDovi(int value) { m_convert_dovi = value; }
+  enum ELType GetDoviElType() const { return m_dovi_el_type; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
   static bool       h264_sequence_header(const uint8_t *data, const uint32_t size, h264_sequence *sequence);
@@ -152,4 +160,5 @@ protected:
   AVCodecID         m_codec;
   bool              m_start_decode;
   int               m_convert_dovi;
+  enum ELType       m_dovi_el_type;
 };


### PR DESCRIPTION
## Description
Provide enhanced user configurable options for VC-1 hardware acceleration, based on selection criteria

## Motivation and context
Currently there is no option to configure hardware acceleration for VC-1 playback. This presents issues in some instances such as hardware accelerated VC-1 decoding is subject to forced de-interlacing performed on even progressive content, resulting in considerable resolution loss for this content. It appears hardware such as the S922X SoCs are powerful enough to perform software decoding of even 1080p24 content using the ffmpeg libraries for VC-1 playback.

Options are: Never, Always, HD and up, and Exclude 24p. Defaults to Always (to retain existing behavior in lieu of user setting this option).

## How has this been tested?
Have tested multiple VC-1 content with all settings, including 24p, and interlaced content to ensure expected behavior. As it appears no supported Amlogic hardware can perform sufficient and acceptable software decoding of interlaced VC-1, and therefore would still rely on hardware acceleration for these instances.

## What is the effect on users?
Provide more flexibility to the user so they can choose which options best suit their needs for VC-1 content playback, and provide the highest video quality and functionality.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
