### PR TITLE
Enhanced VC-1 Acceleration Options

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23261,7 +23261,7 @@ msgstr ""
 msgctxt "#39003"
 msgid "Accelerate h264"
 msgstr ""
- 
+
 #: system/settings/settings.xml
 msgctxt "#39036"
 msgid "Accelerate VC1"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23243,6 +23243,11 @@ msgid "HD and up"
 msgstr ""
 
 #: system/settings/settings.xml
+msgctxt "#39037"
+msgid "Exclude 24p"
+msgstr ""
+
+#: system/settings/settings.xml
 msgctxt "#39001"
 msgid "Accelerate MPEG2"
 msgstr ""
@@ -23255,6 +23260,11 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39003"
 msgid "Accelerate h264"
+msgstr ""
+ 
+#: system/settings/settings.xml
+msgctxt "#39036"
+msgid "Accelerate VC1"
 msgstr ""
 
 #. Description of category "Library" with label #14202

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -218,6 +218,29 @@
           <control type="spinner" format="string" />
           <control type="edit" format="integer" />
         </setting>
+        <setting id="videoplayer.useamcodecvc1" type="integer" label="39036">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="20420">9999</option>   <!-- Never -->
+              <option label="39037">9998</option>  <!-- Exclude 24p -->
+              <option label="39000">800</option>  <!-- HD -->
+              <option label="20422">0</option>  <!-- Always -->
+            </options>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useamcodec" operator="is">true</condition> <!-- USE AMCODEC -->
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+          <control type="edit" format="integer" />
+        </setting>		
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -227,6 +227,25 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       CLog::Log(LOGDEBUG, "{}::{} - amcodec does not support RMVB", __MODULE_NAME__, __FUNCTION__);
       goto FAIL;
     case AV_CODEC_ID_VC1:
+      if (m_hints.width <= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1))
+      {
+        if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1) != 9998)
+        {
+          CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",
+            CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+            CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+          goto FAIL;
+        }
+        else if (m_hints.fpsrate <= 24000)
+        {
+          CLog::Log(LOGDEBUG, "CDVDVideoCodecAmlogic::vc1 size check failed {:d}",
+            CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+            CSettings::SETTING_VIDEOPLAYER_USEAMCODECVC1));
+          goto FAIL;
+        }
+      }
       m_pFormatName = "am-vc1";
       break;
     case AV_CODEC_ID_WMV3:

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -124,6 +124,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG2 = "videoplayer.useamcodecmpeg2";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECMPEG4 = "videoplayer.useamcodecmpeg4";
   static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECH264 = "videoplayer.useamcodech264";
+  static constexpr auto SETTING_VIDEOPLAYER_USEAMCODECVC1 = "videoplayer.useamcodecvc1";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";


### PR DESCRIPTION
## Description
Provide enhanced user configurable options for VC-1 hardware acceleration, based on selection criteria


## Motivation and context
Currently there is no option to configure hardware acceleration for VC-1 playback. This presents issues in some instances such as hardware accelerated VC-1 decoding is subject to forced de-interlacing performed on even progressive content, resulting in considerable resolution loss for this content. It appears hardware such as the S922X SoCs are powerful enough to perform software decoding of even 1080p24 content using the ffmpeg libraries for VC-1 playback.

## How has this been tested?
Have tested multiple VC-1 content with all settings, including 24p, and interlaced content to ensure expected behavior. As it appears no supported Amlogic hardware can perform sufficient and acceptable software decoding of interlaced VC-1, and therefore would still rely on hardware acceleration for these instances.

## What is the effect on users?
Provide more flexibility to the user so they can choose which options best suit their needs for VC-1 content playback, and provide the highest video quality and functionality.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
