### PR TITLE
BitstreamConverter: Refactor Dolby Vision RPU processing

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8836,7 +8836,19 @@ msgctxt "#14427"
 msgid "Player-Led"
 msgstr ""
 
-#empty strings from id 14428 to 15010
+#. Title of Dolby Vision level 5 metadata zero override setting
+#: system/settings/settings.xml
+msgctxt "#14428"
+msgid "Override level 5 metadata to zero"
+msgstr ""
+
+#. Help text for setting "Dolby Vision: Override level 5 metadata to zero" of label #39202
+#: system/settings/settings.xml
+msgctxt "#14429"
+msgid "If enabled, Dolby Vision files will have level 5 (active area) metadata overridden to zero offsets. Enable if your TV has issues with incorrectly cropped image in Dolby Vision playback."
+msgstr ""
+
+#empty strings from id 14430 to 15010
 
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/video/VideoDatabase.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3902,6 +3902,15 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="coreelec.amlogic.dovizerolevel5" type="boolean" label="14428" help="14429" parent="coreelec.amlogic.dolbyvisionled">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="visible" setting="coreelec.amlogic.dolbyvisionled" operator="is">0</dependency>
+          </dependencies>
+        </setting>
       </group>
     </category>
     <category id="cache" label="439" help="36399">

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -307,6 +307,15 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       m_pFormatName = "am-h265";
       m_bitstream = new CBitstreamConverter();
       m_bitstream->Open(m_hints.codec, m_hints.extradata.GetData(), m_hints.extradata.GetSize(), true);
+
+      if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+              CSettings::SETTING_COREELEC_AMLOGIC_DV_LED) == AML_DV_TV_LED)
+      {
+        m_bitstream->SetDoviZeroLevel5(
+            CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                CSettings::SETTING_COREELEC_AMLOGIC_DOVIZEROLEVEL5));
+      }
+
       // make sure we do not leak the existing m_hints.extradata
       m_hints.extradata = {};
       m_hints.extradata = FFmpegExtraData(m_bitstream->GetExtraSize());

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -460,6 +460,7 @@ public:
   static constexpr auto SETTING_COREELEC_AMLOGIC_DISABLEGUISCALING = "coreelec.amlogic.disableguiscaling";
   static constexpr auto SETTING_COREELEC_AMLOGIC_DV_DISABLE = "coreelec.amlogic.disabledolbyvision";
   static constexpr auto SETTING_COREELEC_AMLOGIC_DV_LED = "coreelec.amlogic.dolbyvisionled";
+  static constexpr auto SETTING_COREELEC_AMLOGIC_DOVIZEROLEVEL5 = "coreelec.amlogic.dovizerolevel5";
   static constexpr auto SETTING_CACHE_HARDDISK = "cache.harddisk";
   static constexpr auto SETTING_CACHEVIDEO_DVDROM = "cachevideo.dvdrom";
   static constexpr auto SETTING_CACHEVIDEO_LAN = "cachevideo.lan";

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -22,13 +22,6 @@
 
 #include <algorithm>
 
-extern "C"
-{
-#ifdef HAVE_LIBDOVI
-#include <libdovi/rpu_parser.h>
-#endif
-}
-
 enum {
   AVC_NAL_SLICE=1,
   AVC_NAL_DPA,
@@ -277,55 +270,6 @@ static bool has_sei_recovery_point(const uint8_t *p, const uint8_t *end)
 
   return false;
 }
-
-#ifdef HAVE_LIBDOVI
-// The returned data must be freed with `dovi_data_free`
-// May be NULL if no conversion was done
-static const DoviData* convert_dovi_rpu_nal(uint8_t* buf, uint32_t nal_size)
-{
-  DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nal_size);
-  const DoviRpuDataHeader* header = dovi_rpu_get_header(rpu);
-  const DoviData* rpu_data = NULL;
-
-  if (header && header->guessed_profile == 7)
-  {
-    int ret = dovi_convert_rpu_with_mode(rpu, 2);
-    if (ret < 0)
-      goto done;
-
-    rpu_data = dovi_write_unspec62_nalu(rpu);
-  }
-
-done:
-  dovi_rpu_free_header(header);
-  dovi_rpu_free(rpu);
-
-  return rpu_data;
-}
-
-static enum ELType get_dovi_el_type(uint8_t* buf, uint32_t nal_size)
-{
-  DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nal_size);
-  const DoviRpuDataHeader* header = dovi_rpu_get_header(rpu);
-  enum ELType el_type = ELType::TYPE_NONE;
-
-  if (header && (header->guessed_profile == 4 || header->guessed_profile == 7))
-  {
-    if (header->el_type)
-    {
-      if (StringUtils::EqualsNoCase(header->el_type, "FEL"))
-        el_type = ELType::TYPE_FEL;
-      else if (StringUtils::EqualsNoCase(header->el_type, "MEL"))
-        el_type = ELType::TYPE_MEL;
-    }
-  }
-
-  dovi_rpu_free_header(header);
-  dovi_rpu_free(rpu);
-
-  return el_type;
-}
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -757,29 +701,20 @@ bool CBitstreamConverter::Convert(uint8_t *pData_bl, int iSize_bl, uint8_t *pDat
       {
         const uint8_t *nalu_62_data = buf;
 #ifdef HAVE_LIBDOVI
-        const DoviData* rpu_data = NULL;
-#endif
+        const DoviData* rpu_data = processDoviRpu(buf, size);
 
-        if (m_convert_dovi)
+        if (rpu_data)
         {
-#ifdef HAVE_LIBDOVI
-          // Convert the RPU itself
-          rpu_data = convert_dovi_rpu_nal(buf, size);
-          if (rpu_data)
-          {
-            nalu_62_data = rpu_data->data;
-            size = rpu_data->len;
-          }
-#endif
+          nalu_62_data = rpu_data->data;
+          size = rpu_data->len;
         }
+#endif
 
         BitstreamAllocAndCopy(&m_convertBuffer, &offset, nalu_62_data, size, nal_type);
 
 #ifdef HAVE_LIBDOVI
         if (rpu_data)
           dovi_data_free(rpu_data);
-
-        m_dovi_el_type = get_dovi_el_type((uint8_t *)nalu_62_data, size);
 #endif
       }
       else
@@ -1183,14 +1118,13 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
         }
       }
 
-      if (write_buf && (m_convert_dovi || m_dovi_el_type == ELType::TYPE_NONE))
+      if (write_buf)
       {
         if (unit_type == HEVC_NAL_UNSPEC62)
         {
 #ifdef HAVE_LIBDOVI
           // Convert the RPU itself
-          rpu_data = convert_dovi_rpu_nal(buf, nal_size);
-          m_dovi_el_type = get_dovi_el_type(buf, nal_size);
+          rpu_data = processDoviRpu(buf, nal_size);
           if (rpu_data)
           {
             buf_to_write = rpu_data->data;
@@ -1871,3 +1805,54 @@ bool CBitstreamConverter::h264_sequence_header(const uint8_t *data, const uint32
 
     return changed;
 }
+
+#ifdef HAVE_LIBDOVI
+// Processes Dolby Vision RPU
+//   - Converts to profile 8.1 if `m_convert_dovi` is enabled
+//   - Updates `m_dovi_el_type` according to the current header
+//
+// The returned data must be freed with `dovi_data_free`
+// May be NULL if no processing was done or if parsing errored
+const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nal_size)
+{
+  DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nal_size);
+  const DoviRpuDataHeader* header = dovi_rpu_get_header(rpu);
+  const DoviData* rpu_data = NULL;
+
+  int ret = 0;
+  bool processed = false;
+
+  if (!header)
+  {
+    dovi_rpu_free(rpu);
+    return rpu_data;
+  }
+
+  if (m_dovi_el_type == ELType::TYPE_NONE && header->el_type &&
+      (header->guessed_profile == 4 || header->guessed_profile == 7))
+  {
+    if (StringUtils::EqualsNoCase(header->el_type, "FEL"))
+      m_dovi_el_type = ELType::TYPE_FEL;
+    else if (StringUtils::EqualsNoCase(header->el_type, "MEL"))
+      m_dovi_el_type = ELType::TYPE_MEL;
+  }
+
+  if (m_convert_dovi && header->guessed_profile == 7)
+  {
+    ret = dovi_convert_rpu_with_mode(rpu, 2);
+    if (ret < 0)
+      goto done;
+
+    processed = true;
+  }
+
+  if (processed)
+    rpu_data = dovi_write_unspec62_nalu(rpu);
+
+done:
+  dovi_rpu_free_header(header);
+  dovi_rpu_free(rpu);
+
+  return rpu_data;
+}
+#endif

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -339,6 +339,7 @@ CBitstreamConverter::CBitstreamConverter()
   m_convert_dovi = false;
   m_removeDovi = false;
   m_removeHdr10Plus = false;
+  m_setDoviZeroLevel5 = false;
   m_dovi_el_type = ELType::TYPE_NONE;
   m_combine = false;
 }
@@ -1809,6 +1810,7 @@ bool CBitstreamConverter::h264_sequence_header(const uint8_t *data, const uint32
 #ifdef HAVE_LIBDOVI
 // Processes Dolby Vision RPU
 //   - Converts to profile 8.1 if `m_convert_dovi` is enabled
+//   - Sets level 5 metadata to 0 offsets if `m_setDoviZeroLevel5` is enabled
 //   - Updates `m_dovi_el_type` according to the current header
 //
 // The returned data must be freed with `dovi_data_free`
@@ -1840,6 +1842,15 @@ const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nal_s
   if (m_convert_dovi && header->guessed_profile == 7)
   {
     ret = dovi_convert_rpu_with_mode(rpu, 2);
+    if (ret < 0)
+      goto done;
+
+    processed = true;
+  }
+
+  if (m_setDoviZeroLevel5)
+  {
+    ret = dovi_rpu_set_active_area_offsets(rpu, 0, 0, 0, 0);
     if (ret < 0)
       goto done;
 

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -122,6 +122,7 @@ public:
   void SetConvertDovi(bool value) { m_convert_dovi = value; }
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
+  void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
   enum ELType GetDoviElType() const { return m_dovi_el_type; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -17,6 +17,10 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
 #include <libavcodec/avcodec.h>
+
+#ifdef HAVE_LIBDOVI
+#include <libdovi/rpu_parser.h>
+#endif
 }
 
 typedef struct
@@ -145,6 +149,10 @@ protected:
                                     const uint8_t* in,
                                     uint32_t in_size,
                                     uint8_t nal_type);
+
+#ifdef HAVE_LIBDOVI
+  const DoviData* processDoviRpu(uint8_t* buf, uint32_t nal_size);
+#endif
 
   typedef struct omx_bitstream_ctx {
       uint8_t  length_size;

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -181,5 +181,6 @@ protected:
   bool              m_convert_dovi;
   bool              m_removeDovi;
   bool              m_removeHdr10Plus;
+  bool              m_setDoviZeroLevel5;
   enum ELType       m_dovi_el_type;
 };


### PR DESCRIPTION
And add option to set level 5 metadata to zero offsets.