### PR TITLE
Fix interlaced A/V sync and video_rate on Amlogic

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1901,36 +1901,45 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
   am_private->video_ratio      = ((int32_t)video_ratio.num << 16) | video_ratio.den;
   am_private->video_ratio64    = ((int64_t)video_ratio.num << 32) | video_ratio.den;
 
-  // handle video rate
+  // handle video rate — UNIT_FREQ (96000) / fps gives the decoder tick count
+  // per frame.  Common values:
+  //   23.976fps → 4004,  24fps → 4000,  25fps → 3840,
+  //   29.97fps  → 3203,  30fps → 3200,  50fps → 1920,  59.94fps → 1602
   if (hints.fpsrate > 0 && hints.fpsscale != 0)
   {
-    // then ffmpeg avg_frame_rate next
     am_private->video_rate = 0.5f + (float)UNIT_FREQ * hints.fpsscale / hints.fpsrate;
   }
   else
-    am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 30000;
+    am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 30000; // ~29.97fps fallback
 
-  // check for 1920x1080, interlaced, 25 fps
-  // incorrectly reported as 50 fps (yes, video_rate == 1920)
-  if (hints.width == 1920 && am_private->video_rate == 1920)
+  // Interlaced content reported at field rate needs converting to frame rate
+  // for the decoder firmware.  video_rate <= 1920 means >~48 fields/s:
+  //   PAL  50i:    1920 → 3840  (25fps)
+  //   NTSC 59.94i: 1602 → 3203  (29.97fps)
+  //   NTSC 60i:    1600 → 3200  (30fps)
+  // Recalculate from source (fpsscale * 2) to avoid rounding error from
+  // doubling the already-rounded field rate.  Gate on hints.interlaced to
+  // avoid halving genuine progressive content (720p50, 1080p50, etc.).
+  if (hints.interlaced && am_private->video_rate <= 1920)
   {
     CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder video_rate exception");
-    am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 25000;
+    am_private->video_rate = 0.5f + (float)UNIT_FREQ * hints.fpsscale * 2 / hints.fpsrate;
   }
 
-  // check for SD h264 content incorrectly reported as 60 fsp
-  // mp4/avi containers :(
-  if (hints.codec == AV_CODEC_ID_H264 && hints.width <= 720 && am_private->video_rate == 1602)
+  // SD H.264 in mp4/avi containers can report wrong fps due to unreliable
+  // container-level timing metadata (60fps or 30fps instead of 23.976fps).
+  // Gate on codec_tag != 0: mp4 ('avc1') and avi ('H264') set a FourCC,
+  // while MKV/TS leave it at 0 and derive timing from the stream itself.
+  if (hints.codec == AV_CODEC_ID_H264 && hints.codec_tag != 0 && hints.width <= 720)
   {
-    CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder video_rate exception");
-    am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 24000;
-  }
-
-  // check for SD h264 content incorrectly reported as some form of 30 fsp
-  // mp4/avi containers :(
-  if (hints.codec == AV_CODEC_ID_H264 && hints.width <= 720)
-  {
-    if (am_private->video_rate >= 3200 && am_private->video_rate <= 3210)
+    // 59.94fps (video_rate 1602) → actually 23.976fps (video_rate 4004)
+    if (am_private->video_rate == 1602)
+    {
+      CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder video_rate exception");
+      am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 24000;
+    }
+    // ~29.97-30fps (video_rate 3200-3210) → actually 23.976fps (video_rate 4004)
+    else if (am_private->video_rate >= 3200 && am_private->video_rate <= 3210)
     {
       CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder video_rate exception");
       am_private->video_rate = 0.5f + (float)UNIT_FREQ * 1001 / 24000;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -349,7 +349,7 @@ void CVideoPlayerVideo::Process()
   int iDropDirective;
   bool onlyPrioMsgs = false;
 
-  std::string vfmt;
+  m_vfmt.clear();
   int vfmtCheckCount = 0;
 
   m_videoStats.Start();
@@ -644,10 +644,10 @@ void CVideoPlayerVideo::Process()
         {
           CSysfsPath frame_format{"/sys/class/deinterlace/di0/frame_format"};
           if (frame_format.Exists())
-            vfmt = frame_format.Get<std::string>().value();
-          if (vfmt.size() > 4)
-            m_processInfo.SetVideoInterlaced(vfmt.compare("progressive"));
-          CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::DEMUXER_PACKET - checking interlace vfmt: {}", vfmt);
+            m_vfmt = frame_format.Get<std::string>().value();
+          if (m_vfmt.size() > 4)
+            m_processInfo.SetVideoInterlaced(m_vfmt.compare("progressive"));
+          CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::DEMUXER_PACKET - checking interlace vfmt: {}", m_vfmt);
         }
       }
       else
@@ -728,7 +728,12 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
   {
     bool hasTimestamp = true;
 
-    if (m_processInfo.GetVideoInterlaced() &&
+    // Detect progressive content misidentified as interlaced: if picture
+    // duration consistently equals double what the fps implies, halve fps.
+    // Skip when the hardware deinterlace module has confirmed interlaced
+    // content (vfmt) — MBAFF streams legitimately mix field and frame
+    // output, and the full-frame duration would falsely trigger this.
+    if (m_processInfo.GetVideoInterlaced() && m_vfmt != "interlace" &&
         MathUtils::FloatEquals(static_cast<float>(m_picture.iDuration), static_cast<float>(2 * DVD_TIME_BASE) / m_processInfo.GetVideoFps(), 700.0f))
     {
       if (++m_retryProgressive > 3)
@@ -839,7 +844,26 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
       msg.player = VideoPlayer_VIDEO;
       msg.cachetime = DVD_MSEC_TO_TIME(50); //! @todo implement
       msg.cachetotal = DVD_MSEC_TO_TIME(100); //! @todo implement
-      msg.timestamp = hasTimestamp ? (pts + m_renderManager.GetDelay() * 1000) : DVD_NOPTS_VALUE;
+
+      // Amlogic hardware deinterlace pipeline latency compensation.
+      // When interlaced content is decoded by AML hardware, the VFM pipeline
+      // includes a deinterlace module (di0) that buffers multiple fields before
+      // producing output (buffer_keep_count=3, start_frame_drop=2, plus post-
+      // processing). Kodi captures PTS via V4L2 DQBUF *before* the DI stage,
+      // so the frame appears on screen ~240ms later than Kodi's sync expects.
+      // Shift the video start timestamp forward to delay audio accordingly.
+      double diCompensation = 0;
+      if (m_processInfo.GetVideoInterlaced() && m_processInfo.IsVideoHwDecoder() &&
+          CSysfsPath{"/sys/class/deinterlace/di0/frame_format"}.Exists())
+      {
+        constexpr int DI_PIPELINE_FIELDS = 12;
+        diCompensation = DI_PIPELINE_FIELDS * DVD_TIME_BASE / m_fFrameRate;
+        CLog::Log(LOGDEBUG, "CVideoPlayerVideo - DI pipeline latency compensation: "
+                  "{:.0f}ms ({} fields at {:.1f}Hz)",
+                  diCompensation / (DVD_TIME_BASE / 1000), DI_PIPELINE_FIELDS, m_fFrameRate);
+      }
+
+      msg.timestamp = hasTimestamp ? (pts + m_renderManager.GetDelay() * 1000 + diCompensation) : DVD_NOPTS_VALUE;
       m_messageParent.Put(std::make_shared<CDVDMsgType<SStartMsg>>(CDVDMsg::PLAYER_STARTED, msg));
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -108,6 +108,7 @@ protected:
   double m_iSubtitleDelay;
 
   int m_retryProgressive;
+  std::string m_vfmt;
   int m_iLateFrames;
   int m_iDroppedFrames;
   int m_iDroppedRequest;


### PR DESCRIPTION
## Summary

Three fixes for interlaced A/V sync on Amlogic.

The `video_rate` exception logic in AMLCodec.cpp had a few problems. The interlaced field-to-frame rate correction checked `hints.width == 1920` instead of `hints.interlaced`, so it missed SD interlaced content (576i50) and would incorrectly halve genuine 1080p50. It also used hardcoded NTSC pulldown math instead of deriving from the actual stream. Separately, the SD H.264 fps overrides (60fps/30fps to 23.976) fired for all containers including MKV/TS where stream-level timing is reliable — now limited to mp4/avi (`codec_tag != 0`) where container metadata actually lies.

In VideoPlayerVideo.cpp, the progressive fallback heuristic (which halves fps when picture duration consistently matches 2x the expected frame time) was false-triggering on MBAFF H.264 streams. MBAFF legitimately alternates between 20ms field output and 40ms full-frame output, and the 40ms frames looked like progressive to the heuristic, dropping fps from 50 to 25. Added a check against di0's `frame_format` sysfs — if the hardware deinterlace module says "interlace", trust it over the duration heuristic.

Also in VideoPlayerVideo.cpp: the di0 deinterlace pipeline buffers several fields before producing output, but Kodi captures PTS at V4L2 DQBUF (before the DI stage), so frames show up on screen ~240ms late. Audio ends up consistently ahead of video. This adds a 12-field-period timestamp shift when interlaced + AML HW decoder + di0 are all present.