### PR TITLE
3D: Fixed wrong aspect ratio for HTAB and HSBS videos

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1509,9 +1509,19 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
     if (entry)
     {
       if (strcmp(entry->value, "left_right") == 0 || strcmp(entry->value, "right_left") == 0)
-        dar /= (st->codecpar->width / 1920.0);
+      {
+        if (st->codecpar->width > 1920)
+          dar /= (st->codecpar->width / 1920.0);
+        else
+          dar /= 2;
+      }
       else if (strcmp(entry->value, "top_bottom") == 0 || strcmp(entry->value, "bottom_top") == 0)
-        dar *= (st->codecpar->height / 1080.0);
+      {
+        if (st->codecpar->height > 1080)
+          dar *= (st->codecpar->height / 1080.0);
+        else
+          dar *= 2;
+      }
     }
     return dar;
   }


### PR DESCRIPTION
## Description
Commit https://github.com/CoreELEC/xbmc/commit/de94434749a6b934022b7815838408bdb7e3fc8a caused a regression to HSBS/HTAB video playback aspect ratio. Since HSBS videos always have a width <= 1920 and HTAB videos always have a height <= 1080, the previous ```dar``` calculation is used for those. Otherwise the videos are FSBS or FTAB and the calculation introduced with  ```de94434```.

## Motivation and context
This commit fixes the wrong ```dar``` calculation for HSBS/HTAB videos.

## How has this been tested?
Several 720p/1080p HSBS/HTAB and a FTAB video

## What is the effect on users?
FSBS/HTAB and HSBS/HTAB video playback has the correct aspect ratio.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
