### PR TITLE
3D: Fixed MVC PGS subtitles have no depth

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -593,6 +593,11 @@ void CVideoPlayerVideo::Process()
       DemuxPacket* pPacket = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacket();
       bool bPacketDrop = std::static_pointer_cast<CDVDMsgDemuxerPacket>(pMsg)->GetPacketDrop();
 
+      // Carry 3D MVC subtitle depth (ss_offset_sequence_id from MPLS) into
+      // the video picture so ProcessOverlays can apply the correct stereo
+      // depth offset to PGS subtitles via CDVDOverlay::m_3dSubtitleDepth.
+      m_iSubtitlePlane = pPacket->subtitlePlane;
+
       if (m_stalled)
       {
         CLog::Log(LOGDEBUG, "CVideoPlayerVideo - Stillframe left, switching to normal playback");
@@ -695,6 +700,7 @@ void CVideoPlayerVideo::UpdatePlayerInfo()
 bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
 {
   CDVDVideoCodec::VCReturn decoderState = m_pVideoCodec->GetPicture(&m_picture);
+  m_picture.m_3dSubtitleDepth = m_iSubtitlePlane;
 
   if (decoderState == CDVDVideoCodec::VC_BUFFER)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -138,6 +138,7 @@ protected:
   CDVDMessageQueue m_messageQueue;
   CDVDMessageQueue& m_messageParent;
   CDVDStreamInfo m_hints;
+  int            m_iSubtitlePlane{0}; ///< 3D MVC subtitle depth plane (ss_offset_sequence_id)
   std::unique_ptr<CDVDVideoCodec> m_pVideoCodec;
   CPtsTracker m_ptsTracker;
   std::list<DVDMessageListItem> m_packets;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -274,8 +274,8 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
 
 int GetStereoscopicDepth(bool isPgs, int subtitleDepth)
 {
-  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::MONO &&
-      CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::OFF)
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RenderStereoMode::MONO ||
+      CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RenderStereoMode::OFF)
   {
     // 2D display, so there's no subtitle depth
     return 0;


### PR DESCRIPTION
## Description
3D MVC PGS subtitles had no depth because the depth info never had been carried over to the videoplayer. Also a logical error is fixed which led GetStereoscopicDepth to always return 0 depth for PGS subtitles.

## Motivation and context
It is much more comfortable if 3D subtitles are shown with the intended depth.

## How has this been tested?
Several 3D BD ISOs with subtitles turned on.

## What is the effect on users?
3D MVC PGS subtitles are shown with the correct depth.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
