### PR TITLE
Add HDR Vivid detection support

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -371,9 +371,11 @@
       <return>OSD</return>
       <enter>OSD</enter>
       <ok>OSD</ok>
+      <launch_media_select>OSD</launch_media_select>
       <return mod="longpress">PlayPause</return>
       <enter mod="longpress">PlayPause</enter>
       <ok mod="longpress">PlayPause</ok>
+      <launch_media_select mod="longpress">PlayPause</launch_media_select>
       <m>OSD</m>
       <menu>OSD</menu>
       <i>Info</i>
@@ -429,6 +431,7 @@
       <return>OSD</return>
       <enter>OSD</enter>
       <ok>OSD</ok>
+      <launch_media_select>OSD</launch_media_select>
       <m>OSD</m>
       <menu>OSD</menu>
       <i>Info</i>
@@ -499,6 +502,8 @@
       <enter mod="longpress">PlayPause</enter>
       <ok>OSD</ok>
       <ok mod="longpress">PlayPause</ok>
+      <launch_media_select>OSD</launch_media_select>
+      <launch_media_select mod="longpress">PlayPause</launch_media_select>
       <m>OSD</m>
       <menu>OSD</menu>
       <i>Info</i>
@@ -569,6 +574,7 @@
       <return>Rotate</return>
       <enter>Rotate</enter>
       <ok>Rotate</ok>
+      <launch_media_select>Rotate</launch_media_select>
       <r>Rotate</r>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
@@ -578,6 +584,7 @@
       <return>NextCalibration</return>
       <enter>NextCalibration</enter>
       <ok>NextCalibration</ok>
+      <launch_media_select>NextCalibration</launch_media_select>
       <d>ResetCalibration</d>
       <r>NextResolution</r>
     </keyboard>
@@ -587,6 +594,7 @@
       <return>NextCalibration</return>
       <enter>NextCalibration</enter>
       <ok>NextCalibration</ok>
+      <launch_media_select>NextCalibration</launch_media_select>
       <d>ResetCalibration</d>
     </keyboard>
   </ScreenCalibration>
@@ -727,11 +735,13 @@
       <return>OSD</return>
       <enter>OSD</enter>
       <ok>OSD</ok>
+      <launch_media_select>OSD</launch_media_select>
       <g>ActivateWindow(PVRChannelGuide)</g>
       <c>ActivateWindow(PVROSDChannels)</c>
       <return mod="longpress">ActivateWindow(PVROSDChannels)</return>
       <enter mod="longpress">ActivateWindow(PVROSDChannels)</enter>
       <ok mod="longpress">ActivateWindow(PVROSDChannels)</ok>
+      <launch_media_select mod="longpress">ActivateWindow(PVROSDChannels)</launch_media_select>
       <leftquote>DialogSelectAudio</leftquote>
       <pageup>ChannelUp</pageup>
       <pagedown>ChannelDown</pagedown>
@@ -750,11 +760,13 @@
       <return>OSD</return>
       <enter>OSD</enter>
       <ok>OSD</ok>
+      <launch_media_select>OSD</launch_media_select>
       <g>ActivateWindow(PVRChannelGuide)</g>
       <c>ActivateWindow(PVROSDChannels)</c>
       <return mod="longpress">ActivateWindow(PVROSDChannels)</return>
       <enter mod="longpress">ActivateWindow(PVROSDChannels)</enter>
       <ok mod="longpress">ActivateWindow(PVROSDChannels)</ok>
+      <launch_media_select mod="longpress">ActivateWindow(PVROSDChannels)</launch_media_select>
       <pageup>ChannelUp</pageup>
       <pagedown>ChannelDown</pagedown>
       <channel_up>ChannelUp</channel_up>

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
@@ -220,6 +220,9 @@ extern "C"
 
     /// @brief HDR10+ (SMPTE ST 2094-40 dynamic metadata)
     VIDEOCODEC_HDR_TYPE_HDR10PLUS,
+
+    /// @brief HDR Vivid (T/UWA 005)
+    VIDEOCODEC_HDR_TYPE_HDRVIVID,
   };
   //----------------------------------------------------------------------------
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1963,7 +1963,7 @@ int CAMLCodec::GetAmlDuration() const
   return am_private ? (am_private->video_rate * PTS_FREQ) / UNIT_FREQ : 0;
 };
 
-bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
+bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, bool doviIsFEL)
 {
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_drain = false;
@@ -2107,7 +2107,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
     CLog::Log(LOGINFO, "CAMLCodec::OpenDecoder DOVI: version {:d}.{:d}, profile {:d}{}",
       hints.dovi.dv_version_major, hints.dovi.dv_version_minor, hints.dovi.dv_profile,
       (hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7) ?
-     ((dovi_el_type == ELType::TYPE_FEL) ? ", full enhancement layer" : ", minimum enhancement layer") : "");
+      (doviIsFEL ? ", full enhancement layer" : ", minimum enhancement layer") : "");
 
   m_processInfo.SetVideoDAR(hints.aspect);
   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder decoder timeout: {:d}s",
@@ -2168,7 +2168,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type)
 
     if (hints.dovi.dv_profile == 4 || hints.dovi.dv_profile == 7)
     {
-      if (dovi_el_type != ELType::TYPE_MEL) // use stream path if not MEL
+      if (doviIsFEL) // use stream path if not MEL
       {
         CSysfsPath amdolby_vision_debug{"/sys/class/amdolby_vision/debug"};
         if (amdolby_vision_debug.Exists())

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2801,7 +2801,8 @@ int CAMLCodec::DequeueBuffer()
 CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
 {
   int ret = EAGAIN;
-  float buffer_level = GetBufferLevel();
+  int data_len, free_len, size;
+  float buffer_level = GetBufferLevel(0, data_len, free_len, size);
   std::chrono::milliseconds elapsed_since_last_frame(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()
     - m_tp_last_frame).count());
   bool streambuffer(am_private->gcodec.dec_mode == STREAM_TYPE_STREAM);
@@ -2809,7 +2810,7 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
   if (!m_opened)
     return CDVDVideoCodec::VC_ERROR;
 
-  if (!m_drain && m_buffer_level_ready && buffer_level > m_minimum_buffer_level && (ret = DequeueBuffer()) == 0)
+  if (m_buffer_level_ready && (buffer_level > m_minimum_buffer_level || (m_drain && data_len > 0)) && (ret = DequeueBuffer()) == 0)
   {
     pVideoPicture->iFlags = 0;
 
@@ -2836,7 +2837,7 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
 
     return CDVDVideoCodec::VC_PICTURE;
   }
-  else if (m_drain)
+  else if (m_drain && m_buffer_level_ready && data_len == 0)
     return CDVDVideoCodec::VC_EOF;
   else if (buffer_level > (streambuffer ? 100.0f : 10.0f))
     return CDVDVideoCodec::VC_NONE;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2743,10 +2743,11 @@ int CAMLCodec::ReleaseFrame(const uint32_t index, bool drop)
   return ret;
 }
 
-float CAMLCodec::GetBufferLevel()
+int CAMLCodec::GetBufferLevel()
 {
   int new_chunk = 0, data_len, free_len, size;
-  return GetBufferLevel(new_chunk, data_len, free_len, size);
+  GetBufferLevel(new_chunk, data_len, free_len, size);
+  return data_len;
 }
 
 float CAMLCodec::GetBufferLevel(int new_chunk, int &data_len, int &free_len, int &size)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -63,7 +63,7 @@ public:
   CAMLCodec(CProcessInfo &processInfo);
   virtual ~CAMLCodec();
 
-  bool          OpenDecoder(CDVDStreamInfo &hints, enum ELType dovi_el_type);
+  bool          OpenDecoder(CDVDStreamInfo &hints, bool doviIsFEL);
   bool          Enable_vadj1();
   void          CloseDecoder();
   void          Reset();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -78,6 +78,8 @@ public:
   void          SetVideoRate(int videoRate);
   uint64_t      GetOMXPts() const { return m_cur_pts; }
   uint32_t      GetBufferIndex() const { return m_bufferIndex; };
+  int           GetBufferLevel();
+  float         GetBufferLevel(int new_chunk, int &data_len, int &free_len, int &size);
   static float  OMXPtsToSeconds(int omxpts);
   static int    OMXDurationToNs(int duration);
   int           GetAmlDuration() const;
@@ -96,8 +98,6 @@ private:
   void          CloseAmlVideo();
   std::string   GetVfmMap(const std::string &name);
   void          SetVfmMap(const std::string &name, const std::string &map);
-  float         GetBufferLevel();
-  float         GetBufferLevel(int new_chunk, int &data_len, int &free_len, int &size);
   int           DequeueBuffer();
   unsigned int  GetDecoderVideoRate();
   std::string   GetHDRStaticMetadata(bool dv_enable);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -99,6 +99,8 @@ StreamHdrType ConvertHdrType(const VIDEOCODEC_HDR_TYPE type)
       return StreamHdrType::HDR_TYPE_HLG;
     case VIDEOCODEC_HDR_TYPE_HDR10PLUS:
       return StreamHdrType::HDR_TYPE_HDR10PLUS;
+    case VIDEOCODEC_HDR_TYPE_HDRVIVID:
+      return StreamHdrType::HDR_TYPE_HDRVIVID;
     case VIDEOCODEC_HDR_TYPE_NONE:
       return StreamHdrType::HDR_TYPE_NONE;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -251,6 +251,16 @@ public:
   * Indicates that the decoder supports extention streams.
   */
   virtual bool SupportsExtention() { return false; }
+
+  /**
+  * Get hardware decoder buffer data size.
+  */
+  virtual int GetDataSize() const { return 0; }
+
+  /**
+  * Get hardware decoder buffer data level.
+  */
+  virtual int GetDataLevel() const { return 0; }
 protected:
   CProcessInfo &m_processInfo;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -425,7 +425,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
 
   uint8_t *pData(packet.pData);
   uint32_t iSize(packet.iSize);
-  enum ELType dovi_el_type = ELType::TYPE_NONE;
+  bool doviIsFEL = false;
   int data_added = false;
   bool dual_layer_converted = false;
 
@@ -488,7 +488,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       }
       pData = m_bitstream->GetConvertBuffer();
       iSize = m_bitstream->GetConvertSize();
-      dovi_el_type = m_bitstream->GetDoviElType();
+      doviIsFEL = m_bitstream->GetDoviIsFEL();
     }
     else if (!m_has_keyframe && m_bitparser)
     {
@@ -508,7 +508,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
         m_hints.ptsinvalid = true;
 
       CLog::Log(LOGINFO, "CDVDVideoCodecAmlogic::{}: Open decoder: fps:{:d}/{:d}", __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
-      if (m_Codec && !m_Codec->OpenDecoder(m_hints, dovi_el_type))
+      if (m_Codec && !m_Codec->OpenDecoder(m_hints, doviIsFEL))
         CLog::Log(LOGERROR, "CDVDVideoCodecAmlogic::{}: Failed to open Amlogic Codec", __FUNCTION__);
 
       m_videoBufferPool = std::shared_ptr<CAMLVideoBufferPool>(new CAMLVideoBufferPool());

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -16,11 +16,13 @@
 #include "AMLCodec.h"
 #include "ServiceBroker.h"
 #include "utils/AMLUtils.h"
+#include "utils/HDRCapabilities.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/Thread.h"
+#include "windowing/WinSystem.h"
 
 #define __MODULE_NAME__ "DVDVideoCodecAmlogic"
 
@@ -385,6 +387,16 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
   m_processInfo.SetVideoDAR(m_hints.aspect);
 
   m_has_keyframe = false;
+
+  if (m_bitstream)
+  {
+    const CHDRCapabilities caps = CServiceBroker::GetWinSystem()->GetDisplayHDRCapabilities();
+    if (!caps.SupportsHDR10Plus())
+      m_bitstream->SetRemoveHdr10Plus(true);
+    if (caps.SupportsDolbyVision() == DolbyVisionFormat::DOLBYVISION_TYPE_NONE &&
+        m_hints.dovi.dv_profile != 5)
+      m_bitstream->SetRemoveDovi(true);
+  }
 
   CLog::Log(LOGINFO, "{}: Opened Amlogic Codec", __MODULE_NAME__);
   return true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -426,6 +426,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
   uint8_t *pData(packet.pData);
   uint32_t iSize(packet.iSize);
   bool doviIsFEL = false;
+  bool IsHdr10Plus = false;
   int data_added = false;
   bool dual_layer_converted = false;
 
@@ -489,6 +490,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       pData = m_bitstream->GetConvertBuffer();
       iSize = m_bitstream->GetConvertSize();
       doviIsFEL = m_bitstream->GetDoviIsFEL();
+      IsHdr10Plus = m_bitstream->GetIsHdrPlus();
     }
     else if (!m_has_keyframe && m_bitparser)
     {
@@ -508,6 +510,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
         m_hints.ptsinvalid = true;
 
       m_processInfo.SetDoviIsFEL(doviIsFEL);
+      m_processInfo.SetIsHdr10Plus(IsHdr10Plus);
 
       CLog::Log(LOGINFO, "CDVDVideoCodecAmlogic::{}: Open decoder: fps:{:d}/{:d}", __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
       if (m_Codec && !m_Codec->OpenDecoder(m_hints, doviIsFEL))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -507,6 +507,8 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       if (packet.pts == DVD_NOPTS_VALUE)
         m_hints.ptsinvalid = true;
 
+      m_processInfo.SetDoviIsFEL(doviIsFEL);
+
       CLog::Log(LOGINFO, "CDVDVideoCodecAmlogic::{}: Open decoder: fps:{:d}/{:d}", __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
       if (m_Codec && !m_Codec->OpenDecoder(m_hints, doviIsFEL))
         CLog::Log(LOGERROR, "CDVDVideoCodecAmlogic::{}: Failed to open Amlogic Codec", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -633,6 +633,25 @@ void CDVDVideoCodecAmlogic::SetCodecControl(int flags)
   }
 }
 
+int CDVDVideoCodecAmlogic::GetDataSize() const
+{
+  if (m_Codec)
+    return m_Codec->GetBufferLevel();
+
+  return 0;
+}
+
+int CDVDVideoCodecAmlogic::GetDataLevel() const
+{
+  if (m_Codec)
+  {
+    int data_len, free_len, size;
+    return static_cast<int>(m_Codec->GetBufferLevel(0, data_len, free_len, size));
+  }
+
+  return 0;
+}
+
 void CDVDVideoCodecAmlogic::SetSpeed(int iSpeed)
 {
   if (m_Codec)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -439,6 +439,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
   uint32_t iSize(packet.iSize);
   bool doviIsFEL = false;
   bool IsHdr10Plus = false;
+  bool IsHdrVivid = false;
   int data_added = false;
   bool dual_layer_converted = false;
 
@@ -503,6 +504,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
       iSize = m_bitstream->GetConvertSize();
       doviIsFEL = m_bitstream->GetDoviIsFEL();
       IsHdr10Plus = m_bitstream->GetIsHdrPlus();
+      IsHdrVivid = m_bitstream->GetIsHdrVivid();
     }
     else if (!m_has_keyframe && m_bitparser)
     {
@@ -523,6 +525,7 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
 
       m_processInfo.SetDoviIsFEL(doviIsFEL);
       m_processInfo.SetIsHdr10Plus(IsHdr10Plus);
+      m_processInfo.SetIsHdrVivid(IsHdrVivid);
 
       CLog::Log(LOGINFO, "CDVDVideoCodecAmlogic::{}: Open decoder: fps:{:d}/{:d}", __FUNCTION__, m_hints.fpsrate, m_hints.fpsscale);
       if (m_Codec && !m_Codec->OpenDecoder(m_hints, doviIsFEL))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -79,6 +79,8 @@ public:
   virtual void SetCodecControl(int flags) override;
   virtual const char* GetName(void) override { return (const char*)m_pFormatName; }
   virtual bool SupportsExtention() { return true; }
+  virtual int GetDataSize() const override;
+  virtual int GetDataLevel() const override;
 
 protected:
   void            Close(void);

--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -39,6 +39,7 @@ enum class StreamHdrType
   HDR_TYPE_DOLBYVISION, ///< <b>Dolby Vision</b>, returns `dolbyvision` when used in infolabels
   HDR_TYPE_HLG, ///< <b>HLG</b>, returns `hlg` when used in infolabels
   HDR_TYPE_HDR10PLUS, ///< <b>HDR10+</b>, returns `hdr10plus` when used in infolabels
+  HDR_TYPE_HDRVIVID, ///< <b>HDR Vivid</b>, returns `hdrvivid` when used in infolabels
   HDR_TYPE_COUNT, ///< Sentinel, keep last. Must mirror VIDEOCODEC_HDR_TYPE_COUNT in video_codec.h
 };
 

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -311,6 +311,20 @@ bool CProcessInfo::GetDoviIsFEL()
   return m_doviIsFEL;
 }
 
+void CProcessInfo::SetIsHdr10Plus(bool isHdr10Plus)
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  m_IsHdr10Plus = isHdr10Plus;
+}
+
+bool CProcessInfo::GetIsHdr10Plus()
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  return m_IsHdr10Plus;
+}
+
 EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()
 {
   return VS_INTERLACEMETHOD_DEINTERLACE;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -78,6 +78,7 @@ void CProcessInfo::ResetVideoCodecInfo()
   m_videoQueueLevel = 0;
   m_videoQueueDataLevel = 0;
   m_videoIsInterlaced = false;
+  m_doviIsFEL = false;
   m_deintMethods.clear();
   m_deintMethods.push_back(EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE);
   m_deintMethodDefault = EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE;
@@ -294,6 +295,20 @@ bool CProcessInfo::GetVideoInterlaced()
   std::unique_lock lock(m_videoCodecSection);
 
   return m_videoIsInterlaced;
+}
+
+void CProcessInfo::SetDoviIsFEL(bool isFEL)
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  m_doviIsFEL = isFEL;
+}
+
+bool CProcessInfo::GetDoviIsFEL()
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  return m_doviIsFEL;
 }
 
 EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -325,6 +325,20 @@ bool CProcessInfo::GetIsHdr10Plus()
   return m_IsHdr10Plus;
 }
 
+void CProcessInfo::SetIsHdrVivid(bool isHdrVivid)
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  m_IsHdrVivid = isHdrVivid;
+}
+
+bool CProcessInfo::GetIsHdrVivid()
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  return m_IsHdrVivid;
+}
+
 EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()
 {
   return VS_INTERLACEMETHOD_DEINTERLACE;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -56,6 +56,8 @@ public:
   int GetVideoQueueDataLevel();
   void SetVideoInterlaced(bool interlaced);
   bool GetVideoInterlaced();
+  void SetDoviIsFEL(bool isFEL);
+  bool GetDoviIsFEL();
   virtual EINTERLACEMETHOD GetFallbackDeintMethod();
   virtual void SetSwDeinterlacingMethods();
   void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods);
@@ -158,6 +160,7 @@ protected:
   int m_videoQueueLevel = 0;
   int m_videoQueueDataLevel = 0;
   bool m_videoIsInterlaced;
+  bool m_doviIsFEL;
   std::list<EINTERLACEMETHOD> m_deintMethods;
   EINTERLACEMETHOD m_deintMethodDefault;
   mutable CCriticalSection m_videoCodecSection;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -58,6 +58,8 @@ public:
   bool GetVideoInterlaced();
   void SetDoviIsFEL(bool isFEL);
   bool GetDoviIsFEL();
+  void SetIsHdr10Plus(bool isHdr10Plus);
+  bool GetIsHdr10Plus();
   virtual EINTERLACEMETHOD GetFallbackDeintMethod();
   virtual void SetSwDeinterlacingMethods();
   void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods);
@@ -161,6 +163,7 @@ protected:
   int m_videoQueueDataLevel = 0;
   bool m_videoIsInterlaced;
   bool m_doviIsFEL;
+  bool m_IsHdr10Plus;
   std::list<EINTERLACEMETHOD> m_deintMethods;
   EINTERLACEMETHOD m_deintMethodDefault;
   mutable CCriticalSection m_videoCodecSection;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -60,6 +60,8 @@ public:
   bool GetDoviIsFEL();
   void SetIsHdr10Plus(bool isHdr10Plus);
   bool GetIsHdr10Plus();
+  void SetIsHdrVivid(bool isHdrVivid);
+  bool GetIsHdrVivid();
   virtual EINTERLACEMETHOD GetFallbackDeintMethod();
   virtual void SetSwDeinterlacingMethods();
   void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods);
@@ -164,6 +166,7 @@ protected:
   bool m_videoIsInterlaced;
   bool m_doviIsFEL;
   bool m_IsHdr10Plus;
+  bool m_IsHdrVivid;
   std::list<EINTERLACEMETHOD> m_deintMethods;
   EINTERLACEMETHOD m_deintMethodDefault;
   mutable CCriticalSection m_videoCodecSection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5928,6 +5928,20 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
   info.stereoMode = s.stereo_mode;
   info.flags = s.flags;
   info.hdrType = s.hdrType;
+
+  // handle fallback on broken Dolby Vision path
+  if (info.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+  {
+    if (!aml_dolby_vision_enabled())
+    {
+      const CHDRCapabilities caps = CServiceBroker::GetWinSystem()->GetDisplayHDRCapabilities();
+      info.hdrType = StreamHdrType::HDR_TYPE_HDR10;
+
+      if (!caps.SupportsHDR10() || s.dovi.dv_profile == 4)
+        info.hdrType = StreamHdrType::HDR_TYPE_NONE;
+    }
+  }
+
   if (info.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
   {
     if (info.hdrDetail.length() == 0)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5941,6 +5941,10 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
       if (s.dovi.dv_bl_signal_compatibility_id == 4)
         info.hdrTypeAlt = StreamHdrType::HDR_TYPE_HLG;
     }
+    else if (s.dovi.dv_profile == 7)
+    {
+      info.hdrDetail += m_processInfo->GetDoviIsFEL() ? "FEL" : "MEL";
+    }
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5960,6 +5960,11 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
       info.hdrDetail += m_processInfo->GetDoviIsFEL() ? "FEL" : "MEL";
     }
   }
+  else if (info.hdrType == StreamHdrType::HDR_TYPE_HDR10)
+  {
+    if (m_processInfo->GetIsHdr10Plus())
+      info.hdrType = StreamHdrType::HDR_TYPE_HDR10PLUS;
+  }
   else
   {
     info.hdrDetail = "";

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5964,6 +5964,8 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
   {
     if (m_processInfo->GetIsHdr10Plus())
       info.hdrType = StreamHdrType::HDR_TYPE_HDR10PLUS;
+    else if (m_processInfo->GetIsHdrVivid())
+      info.hdrType = StreamHdrType::HDR_TYPE_HDRVIVID;
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -305,7 +305,15 @@ bool CVideoPlayerVideo::AcceptsData() const
 
 bool CVideoPlayerVideo::HasData() const
 {
-  return m_messageQueue.GetDataSize() > 0;
+  bool ret;
+
+  if (!(ret = (m_messageQueue.GetDataSize() > 0)))
+  {
+    if (m_pVideoCodec && m_processInfo.IsVideoHwDecoder())
+      ret = m_pVideoCodec->GetDataSize() > 0;
+  }
+
+  return ret;
 }
 
 bool CVideoPlayerVideo::IsInited() const
@@ -1088,8 +1096,10 @@ std::string CVideoPlayerVideo::GetPlayerInfo()
   std::ostringstream s;
   int width, height;
   m_processInfo.GetVideoDimensions(width, height);
-  s << "vq:" << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true)) << "%)";
-  s << std::fixed << std::setprecision(3) << m_messageQueue.GetTimeSize();
+  s << "vq:" << std::setw(2) << std::min(99, m_messageQueue.GetLevel()) << "% (" << std::setw(2) << std::min(99, m_messageQueue.GetLevel(true));
+  if (m_pVideoCodec && m_processInfo.IsVideoHwDecoder())
+    s << "%/" << std::setw(2) << std::min(99, m_pVideoCodec->GetDataLevel());
+  s << "%)" << std::fixed << std::setprecision(3) << m_messageQueue.GetTimeSize();
   s << "s, Mb/s:" << std::fixed << std::setprecision(2)
     << static_cast<double>(GetVideoBitrate()) / (1024.0 * 1024.0);
   s << ", dc:"   << m_processInfo.GetVideoDecoderName().c_str();

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -353,6 +353,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value,
           types += ", HLG";
         if (caps.SupportsHDR10Plus())
           types += ", HDR10+";
+        if (caps.SupportsHDRVivid())
+          types += ", HDR Vivid";
         if (caps.SupportsDolbyVision() == DolbyVisionFormat::DOLBYVISION_TYPE_4K30)
           types += ", Dolby Vision up to 4k30Hz";
         if (caps.SupportsDolbyVision() == DolbyVisionFormat::DOLBYVISION_TYPE_4K60)

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -114,7 +114,11 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
                            info.GetInfo() <= PLAYER_OFFSET_POSITION_LAST)))
     return GetPlaylistInfo(value, info);
 
-  const CVideoInfoTag* tag = item->GetVideoInfoTag();
+  const CVideoInfoTag* tag =
+      !CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_DIALOG_PLAYER_PROCESS_INFO, false)
+          ? item->GetVideoInfoTag()
+          : nullptr;
+
   if (tag)
   {
     switch (info.GetInfo())

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -78,6 +78,33 @@ std::string aml_get_cpufamily_name(int cpuid)
   return "Unknown";
 }
 
+bool aml_display_is_widescreen()
+{
+  bool is_widescreen = true;
+  CSysfsPath edid{"/sys/class/amhdmitx/amhdmitx0/edid"};
+
+  if (edid.Exists())
+  {
+    std::string valstr = edid.Get<std::string>().value();
+    size_t pos = valstr.find("Physical size(mm):");
+    if (pos != std::string::npos)
+    {
+      int width_mm = 0, height_mm = 0;
+      sscanf(valstr.c_str() + pos, "Physical size(mm): %d x %d", &width_mm, &height_mm);
+      if (width_mm > 0 && height_mm > 0)
+      {
+          float ratio = static_cast<float>(width_mm) / height_mm;
+          // 16:9 range (with some tolerance)
+          is_widescreen = (ratio > 1.65f) ? 1 : 0;
+          CLog::Log(LOGDEBUG, "AMLUtils: display {} wide screen ({}x{}mm)",
+            is_widescreen ? "is" : "is not", width_mm, height_mm);
+      }
+    }
+  }
+
+  return is_widescreen;
+}
+
 bool aml_display_support_dv()
 {
   static int support_dv = -1;
@@ -317,69 +344,5 @@ void aml_set_3d_video_mode(unsigned int mode, bool framepacking_support, int vie
 
     CSysfsPath("/sys/module/aml_media/parameters/g_framepacking_support", framepacking_support ? 1 : 0);
     CSysfsPath("/sys/module/amvdec_h264mvc/parameters/view_mode", view_mode);
-  }
-}
-
-void aml_probe_hdmi_audio()
-{
-  // Audio {format, channel, freq, cce}
-  // {1, 7, 7f, 7}
-  // {7, 5, 1e, 0}
-  // {2, 5, 7, 0}
-  // {11, 7, 7e, 1}
-  // {10, 7, 6, 0}
-  // {12, 7, 7e, 0}
-
-  int fd = open("/sys/class/amhdmitx/amhdmitx0/edid", O_RDONLY);
-  if (fd >= 0)
-  {
-    char valstr[1024] = {0};
-
-    read(fd, valstr, sizeof(valstr) - 1);
-    valstr[strlen(valstr)] = '\0';
-    close(fd);
-
-    std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
-
-    for (std::vector<std::string>::const_iterator i = probe_str.begin(); i != probe_str.end(); ++i)
-    {
-      if (i->find("Audio") == std::string::npos)
-      {
-        for (std::vector<std::string>::const_iterator j = i + 1; j != probe_str.end(); ++j)
-        {
-          if      (j->find("{1,")  != std::string::npos)
-            printf(" PCM found {1,\n");
-          else if (j->find("{2,")  != std::string::npos)
-            printf(" AC3 found {2,\n");
-          else if (j->find("{3,")  != std::string::npos)
-            printf(" MPEG1 found {3,\n");
-          else if (j->find("{4,")  != std::string::npos)
-            printf(" MP3 found {4,\n");
-          else if (j->find("{5,")  != std::string::npos)
-            printf(" MPEG2 found {5,\n");
-          else if (j->find("{6,")  != std::string::npos)
-            printf(" AAC found {6,\n");
-          else if (j->find("{7,")  != std::string::npos)
-            printf(" DTS found {7,\n");
-          else if (j->find("{8,")  != std::string::npos)
-            printf(" ATRAC found {8,\n");
-          else if (j->find("{9,")  != std::string::npos)
-            printf(" One_Bit_Audio found {9,\n");
-          else if (j->find("{10,") != std::string::npos)
-            printf(" Dolby found {10,\n");
-          else if (j->find("{11,") != std::string::npos)
-            printf(" DTS_HD found {11,\n");
-          else if (j->find("{12,") != std::string::npos)
-            printf(" MAT found {12,\n");
-          else if (j->find("{13,") != std::string::npos)
-            printf(" ATRAC found {13,\n");
-          else if (j->find("{14,") != std::string::npos)
-            printf(" WMA found {14,\n");
-          else
-            break;
-        }
-        break;
-      }
-    }
   }
 }

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -40,6 +40,7 @@ enum AML_DISPLAY_DV_LED
 
 int  aml_get_cpufamily_id();
 std::string aml_get_cpufamily_name(int cpuid = -1);
+bool aml_display_is_widescreen();
 bool aml_display_support_dv();
 bool aml_display_support_3d();
 bool aml_support_hevc();

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -1392,8 +1392,6 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData,
       const uint8_t* buf_to_write = buf;
       int32_t final_nal_size = nal_size;
 
-      bool containsHdr10Plus{false};
-
       if (!m_sps_pps_context.first_idr && IsSlice(unit_type))
       {
         m_sps_pps_context.first_idr = 1;
@@ -1404,13 +1402,15 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData,
         write_buf = false;
 
       // Try removing HDR10+ only if the NAL is big enough, optimization
-      if (m_removeHdr10Plus && unit_type == HEVC_NAL_SEI_PREFIX && nal_size >= 7)
+      if (unit_type == HEVC_NAL_SEI_PREFIX && nal_size >= 7)
       {
-        std::tie(containsHdr10Plus, finalPrefixSeiNalu) =
-            CHevcSei::RemoveHdr10PlusFromSeiNalu(buf, nal_size);
+        if (!m_Hdr10PlusTested && !m_removeHdr10Plus && !m_IsHdr10Plus)
+          m_IsHdr10Plus = CHevcSei::ContainsHdr10Plus(buf, nal_size);
 
-        if (containsHdr10Plus)
+        if (m_removeHdr10Plus)
         {
+          finalPrefixSeiNalu = CHevcSei::RemoveHdr10PlusFromSeiNalu(buf, nal_size);
+
           if (!finalPrefixSeiNalu.empty())
           {
             buf_to_write = finalPrefixSeiNalu.data();
@@ -1456,13 +1456,15 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData,
       }
 #endif
 
-      if (containsHdr10Plus && !finalPrefixSeiNalu.empty())
+      if (m_IsHdr10Plus && !finalPrefixSeiNalu.empty())
         finalPrefixSeiNalu.clear();
     }
 
     buf += nal_size;
     cumul_size += nal_size + m_sps_pps_context.length_size;
   } while (cumul_size < buf_size);
+
+  m_Hdr10PlusTested = true;
 
   return true;
 

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -383,7 +383,6 @@ CBitstreamConverter::CBitstreamConverter()
   m_removeDovi = false;
   m_removeHdr10Plus = false;
   m_setDoviZeroLevel5 = false;
-  m_dovi_el_type = ELType::TYPE_NONE;
   m_combine = false;
 }
 
@@ -850,8 +849,6 @@ bool CBitstreamConverter::Convert(uint8_t *pData_bl, int iSize_bl, uint8_t *pDat
     }
     else
       buf = pData_bl;
-
-    m_dovi_el_type = ELType::TYPE_NONE;
 
     // process bl frame data
     start = buf;
@@ -2121,16 +2118,16 @@ bool CBitstreamConverter::h264_sequence_header(const uint8_t *data, const uint32
 
 #ifdef HAVE_LIBDOVI
 // Processes Dolby Vision RPU
+//   - Sets `m_doviIsFEL` flag to true when DV is profile 7 / FEL
 //   - Converts to profile 8.1 if `m_convert_dovi` is enabled
-//   - Updates `m_dovi_el_type` according to the current header
 //   - Sets level 5 metadata to 0 offsets if `m_setDoviZeroLevel5` is enabled
 //
 // The returned data must be freed with `dovi_data_free`
 // May be NULL if no processing was done or if parsing errored
 const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nalSize)
 {
-  // early exit if no processing option is enabled
-  if (!m_convert_dovi && !m_setDoviZeroLevel5)
+  // early exit if no processing option is enabled and EL type is alredy tested
+  if (m_doviELTested && !m_convert_dovi && !m_setDoviZeroLevel5)
     return NULL;
 
   DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nalSize);
@@ -2146,13 +2143,14 @@ const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nalSi
     return rpuData;
   }
 
-  if (m_dovi_el_type == ELType::TYPE_NONE && header->el_type &&
-      (header->guessed_profile == 4 || header->guessed_profile == 7))
+  if (!m_doviELTested)
   {
-    if (StringUtils::EqualsNoCase(header->el_type, "FEL"))
-      m_dovi_el_type = ELType::TYPE_FEL;
-    else if (StringUtils::EqualsNoCase(header->el_type, "MEL"))
-      m_dovi_el_type = ELType::TYPE_MEL;
+    if (header->el_type && (header->guessed_profile == 4 || header->guessed_profile == 7))
+    {
+      if (StringUtils::EqualsNoCase(header->el_type, "FEL"))
+        m_doviIsFEL = true;
+    }
+    m_doviELTested = true;
   }
 
   if (m_convert_dovi && header->guessed_profile == 7)

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -1407,6 +1407,9 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData,
         if (!m_Hdr10PlusTested && !m_removeHdr10Plus && !m_IsHdr10Plus)
           m_IsHdr10Plus = CHevcSei::ContainsHdr10Plus(buf, nal_size);
 
+        if (!m_HdrVividTested && !m_IsHdrVivid)
+          m_IsHdrVivid = CHevcSei::ContainsHdrVivid(buf, nal_size);
+
         if (m_removeHdr10Plus)
         {
           finalPrefixSeiNalu = CHevcSei::RemoveHdr10PlusFromSeiNalu(buf, nal_size);
@@ -1465,6 +1468,7 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData,
   } while (cumul_size < buf_size);
 
   m_Hdr10PlusTested = true;
+  m_HdrVividTested = true;
 
   return true;
 

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -84,13 +84,6 @@ typedef struct
   int frame_crop_bottom_offset;
 } sps_info_struct;
 
-enum ELType : int
-{
-  TYPE_NONE = 0,
-  TYPE_FEL,
-  TYPE_MEL
-};
-
 class CBitstreamParser
 {
 public:
@@ -124,7 +117,7 @@ public:
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
-  enum ELType GetDoviElType() const { return m_dovi_el_type; }
+  bool GetDoviIsFEL() const { return m_doviIsFEL; }
 
   static bool mpeg2_sequence_header(const uint8_t* data,
                                     const uint32_t size,
@@ -189,5 +182,6 @@ protected:
   bool m_removeDovi;
   bool m_removeHdr10Plus;
   bool m_setDoviZeroLevel5;
-  enum ELType m_dovi_el_type;
+  bool m_doviIsFEL{false};
+  bool m_doviELTested{false};
 };

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -118,6 +118,7 @@ public:
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
   bool GetDoviIsFEL() const { return m_doviIsFEL; }
+  bool GetIsHdrPlus() const { return m_IsHdr10Plus; }
 
   static bool mpeg2_sequence_header(const uint8_t* data,
                                     const uint32_t size,
@@ -184,4 +185,6 @@ protected:
   bool m_setDoviZeroLevel5;
   bool m_doviIsFEL{false};
   bool m_doviELTested{false};
+  bool m_IsHdr10Plus{false};
+  bool m_Hdr10PlusTested{false};
 };

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -119,6 +119,7 @@ public:
   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
   bool GetDoviIsFEL() const { return m_doviIsFEL; }
   bool GetIsHdrPlus() const { return m_IsHdr10Plus; }
+  bool GetIsHdrVivid() const { return m_IsHdrVivid; }
 
   static bool mpeg2_sequence_header(const uint8_t* data,
                                     const uint32_t size,
@@ -187,4 +188,6 @@ protected:
   bool m_doviELTested{false};
   bool m_IsHdr10Plus{false};
   bool m_Hdr10PlusTested{false};
+  bool m_IsHdrVivid{false};
+  bool m_HdrVividTested{false};
 };

--- a/xbmc/utils/HDRCapabilities.h
+++ b/xbmc/utils/HDRCapabilities.h
@@ -24,11 +24,13 @@ public:
   bool SupportsHDR10() const { return m_hdr10; }
   bool SupportsHLG() const { return m_hlg; }
   bool SupportsHDR10Plus() const { return m_hdr10_plus; }
+  bool SupportsHDRVivid() const { return m_hdr_vivid; }
   DolbyVisionFormat SupportsDolbyVision() const { return m_dolby_vision; }
 
   void SetHDR10() { m_hdr10 = true; }
   void SetHLG() { m_hlg = true; }
   void SetHDR10Plus() { m_hdr10_plus = true; }
+  void SetHDRVivid() { m_hdr_vivid = true; }
   void SetDolbyVision() { m_dolby_vision = DolbyVisionFormat::DOLBYVISION_TYPE_4K30; }
   void SetDolbyVision4k60() { m_dolby_vision = DolbyVisionFormat::DOLBYVISION_TYPE_4K60; }
 
@@ -36,5 +38,6 @@ private:
   bool m_hdr10 = false;
   bool m_hlg = false;
   bool m_hdr10_plus = false;
+  bool m_hdr_vivid = false;
   DolbyVisionFormat m_dolby_vision = DolbyVisionFormat::DOLBYVISION_TYPE_NONE;
 };

--- a/xbmc/utils/HevcSei.cpp
+++ b/xbmc/utils/HevcSei.cpp
@@ -150,37 +150,45 @@ std::optional<const CHevcSei*> CHevcSei::FindHdr10PlusSeiMessage(
   return {};
 }
 
-std::pair<bool, const std::vector<uint8_t>> CHevcSei::RemoveHdr10PlusFromSeiNalu(
-    const uint8_t* inData, const size_t inDataLen)
+std::optional<std::tuple<std::vector<uint8_t>, std::vector<CHevcSei>, const CHevcSei*>>
+CHevcSei::FindHdr10Plus(const uint8_t* inData, const size_t inDataLen)
 {
-  bool containsHdr10Plus{false};
-
   std::vector<uint8_t> buf;
   std::vector<CHevcSei> messages = CHevcSei::ParseSeiRbspUnclearedEmulation(inData, inDataLen, buf);
 
-  if (auto res = CHevcSei::FindHdr10PlusSeiMessage(buf, messages))
-  {
-    auto msg = *res;
+  const auto found = CHevcSei::FindHdr10PlusSeiMessage(buf, messages);
+  if (!found)
+    return {};
 
-    containsHdr10Plus = true;
-    if (messages.size() > 1)
-    {
-      // Multiple SEI messages in NALU, remove only the HDR10+ one
-      buf.erase(std::next(buf.begin(), msg->m_msgOffset),
-                std::next(buf.begin(), msg->m_payloadOffset + msg->m_payloadSize));
-      HevcAddStartCodeEmulationPrevention3Byte(buf);
-    }
-    else
-    {
-      // Single SEI message in NALU
-      buf.clear();
-    }
+  return std::make_tuple(std::move(buf), std::move(messages), *found);
+}
+
+bool CHevcSei::ContainsHdr10Plus(const uint8_t* inData, const size_t inDataLen)
+{
+  return CHevcSei::FindHdr10Plus(inData, inDataLen).has_value();
+}
+
+std::vector<uint8_t> CHevcSei::RemoveHdr10PlusFromSeiNalu(
+    const uint8_t* inData, const size_t inDataLen)
+{
+  auto res = CHevcSei::FindHdr10Plus(inData, inDataLen);
+  if (!res)
+    return {};
+
+  auto& [buf, messages, msg] = *res;
+
+  if (messages.size() > 1)
+  {
+    // Multiple SEI messages in NALU, remove only the HDR10+ one
+    buf.erase(std::next(buf.begin(), msg->m_msgOffset),
+              std::next(buf.begin(), msg->m_payloadOffset + msg->m_payloadSize));
+    HevcAddStartCodeEmulationPrevention3Byte(buf);
   }
   else
   {
-    // No HDR10+
+    // Single SEI message in NALU
     buf.clear();
   }
 
-  return std::make_pair(containsHdr10Plus, buf);
+  return std::move(buf);
 }

--- a/xbmc/utils/HevcSei.cpp
+++ b/xbmc/utils/HevcSei.cpp
@@ -192,3 +192,71 @@ std::vector<uint8_t> CHevcSei::RemoveHdr10PlusFromSeiNalu(
 
   return std::move(buf);
 }
+
+std::optional<const CHevcSei*> CHevcSei::FindHdrVividSeiMessage(
+    const std::vector<uint8_t>& buf, const std::vector<CHevcSei>& messages)
+{
+  for (const CHevcSei& sei : messages)
+  {
+    // User Data Registered ITU-T T.35
+    if (sei.m_payloadType == 4 && sei.m_payloadSize >= 7)
+    {
+      CBitstreamReader br(buf.data() + sei.m_payloadOffset, sei.m_payloadSize);
+      const auto itu_t_t35_country_code = br.ReadBits(8);
+      const auto itu_t_t35_terminal_provider_code = br.ReadBits(16);
+      const auto itu_t_t35_terminal_provider_oriented_code = br.ReadBits(16);
+
+      // China, T/UWA 005 (HDR Vivid)
+      if (itu_t_t35_country_code == 0x26 && itu_t_t35_terminal_provider_code == 0x0004 &&
+          itu_t_t35_terminal_provider_oriented_code == 0x0005)
+      {
+        return &sei;
+      }
+    }
+  }
+
+  return {};
+}
+
+std::optional<std::tuple<std::vector<uint8_t>, std::vector<CHevcSei>, const CHevcSei*>>
+CHevcSei::FindHdrVivid(const uint8_t* inData, const size_t inDataLen)
+{
+  std::vector<uint8_t> buf;
+  std::vector<CHevcSei> messages = CHevcSei::ParseSeiRbspUnclearedEmulation(inData, inDataLen, buf);
+
+  const auto found = CHevcSei::FindHdrVividSeiMessage(buf, messages);
+  if (!found)
+    return {};
+
+  return std::make_tuple(std::move(buf), std::move(messages), *found);
+}
+
+bool CHevcSei::ContainsHdrVivid(const uint8_t* inData, const size_t inDataLen)
+{
+  return CHevcSei::FindHdrVivid(inData, inDataLen).has_value();
+}
+
+std::vector<uint8_t> CHevcSei::RemoveHdrVividFromSeiNalu(
+    const uint8_t* inData, const size_t inDataLen)
+{
+  auto res = CHevcSei::FindHdrVivid(inData, inDataLen);
+  if (!res)
+    return {};
+
+  auto& [buf, messages, msg] = *res;
+
+  if (messages.size() > 1)
+  {
+    // Multiple SEI messages in NALU, remove only the HDR Vivid one
+    buf.erase(std::next(buf.begin(), msg->m_msgOffset),
+              std::next(buf.begin(), msg->m_payloadOffset + msg->m_payloadSize));
+    HevcAddStartCodeEmulationPrevention3Byte(buf);
+  }
+  else
+  {
+    // Single SEI message in NALU
+    buf.clear();
+  }
+
+  return std::move(buf);
+}

--- a/xbmc/utils/HevcSei.h
+++ b/xbmc/utils/HevcSei.h
@@ -49,12 +49,14 @@ public:
   static std::optional<const CHevcSei*> FindHdr10PlusSeiMessage(
       const std::vector<uint8_t>& buf, const std::vector<CHevcSei>& messages);
 
-  // Returns a pair with:
-  //   1) a bool for whether or not the NALU SEI payload contains a HDR10+ SEI message.
-  //   2) a vector of bytes:
+  // Returns true if NALU SEI payload contains a HDR10+ SEI message.
+  static bool ContainsHdr10Plus(
+      const uint8_t* inData, const size_t inDataLen);
+
+  // Returns a vector of bytes:
   //      When not empty: the new NALU containing all but the HDR10+ SEI message.
   //      Otherwise: the NALU contained only one HDR10+ SEI and can be discarded.
-  static std::pair<bool, const std::vector<uint8_t>> RemoveHdr10PlusFromSeiNalu(
+  static std::vector<uint8_t> RemoveHdr10PlusFromSeiNalu(
       const uint8_t* inData, const size_t inDataLen);
 
 private:
@@ -62,4 +64,7 @@ private:
   static int ParseSeiMessage(CBitstreamReader& br, std::vector<CHevcSei>& messages);
 
   static std::vector<CHevcSei> ParseSeiRbspInternal(const uint8_t* buf, const size_t len);
+
+  static std::optional<std::tuple<std::vector<uint8_t>, std::vector<CHevcSei>, const CHevcSei*>>
+      FindHdr10Plus(const uint8_t* inData, const size_t inDataLen);
 };

--- a/xbmc/utils/HevcSei.h
+++ b/xbmc/utils/HevcSei.h
@@ -59,6 +59,20 @@ public:
   static std::vector<uint8_t> RemoveHdr10PlusFromSeiNalu(
       const uint8_t* inData, const size_t inDataLen);
 
+  // Returns a HDR Vivid SEI message if present in the list
+  static std::optional<const CHevcSei*> FindHdrVividSeiMessage(
+      const std::vector<uint8_t>& buf, const std::vector<CHevcSei>& messages);
+
+  // Returns true if NALU SEI payload contains a HDR Vivid SEI message.
+  static bool ContainsHdrVivid(
+      const uint8_t* inData, const size_t inDataLen);
+
+  // Returns a vector of bytes:
+  //      When not empty: the new NALU containing all but the HDR Vivid SEI message.
+  //      Otherwise: the NALU contained only one HDR Vivid SEI and can be discarded.
+  static std::vector<uint8_t> RemoveHdrVividFromSeiNalu(
+      const uint8_t* inData, const size_t inDataLen);
+
 private:
   // Parses single SEI message from the reader and pushes it to the list
   static int ParseSeiMessage(CBitstreamReader& br, std::vector<CHevcSei>& messages);
@@ -67,4 +81,7 @@ private:
 
   static std::optional<std::tuple<std::vector<uint8_t>, std::vector<CHevcSei>, const CHevcSei*>>
       FindHdr10Plus(const uint8_t* inData, const size_t inDataLen);
+
+  static std::optional<std::tuple<std::vector<uint8_t>, std::vector<CHevcSei>, const CHevcSei*>>
+      FindHdrVivid(const uint8_t* inData, const size_t inDataLen);
 };

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -709,6 +709,8 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
       return "hlg";
     case StreamHdrType::HDR_TYPE_HDR10PLUS:
       return "hdr10plus";
+    case StreamHdrType::HDR_TYPE_HDRVIVID:
+      return "hdrvivid";
     case StreamHdrType::HDR_TYPE_NONE:
     default:
       return "";

--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -181,9 +181,6 @@ CAMLDRMUtils::CAMLDRMUtils()
   }
 
   aml_init_drmDevice();
-
-  if (aml_get_drmDevice_connected())
-    aml_init_drmDevice_display();
 }
 
 CAMLDRMUtils::~CAMLDRMUtils()
@@ -206,22 +203,42 @@ CAMLDRMUtils::~CAMLDRMUtils()
 void CAMLDRMUtils::CleanAndClose()
 {
   if (m_resources)
+  {
     drmModeFreeResources(m_resources);
+    m_resources = nullptr;
+  }
 
   if (m_connector)
+  {
     drmModeFreeConnector(m_connector);
+    m_connector = nullptr;
+  }
 
   if (m_encoder)
+  {
     drmModeFreeEncoder(m_encoder);
+    m_encoder = nullptr;
+  }
 
   if (m_crtc)
+  {
     drmModeFreeCrtc(m_crtc);
+    m_crtc = nullptr;
+  }
 
   if (m_orig_crtc)
+  {
     free(m_orig_crtc);
+    m_orig_crtc = nullptr;
+  }
 
   if (m_plane)
+  {
     drmModeFreePlane(m_plane);
+    m_plane = nullptr;
+  }
+
+  m_connection = DRM_MODE_DISCONNECTED;
 }
 
 void CAMLDRMUtils::aml_init_drmDevice()
@@ -292,6 +309,9 @@ void CAMLDRMUtils::aml_init_drmDevice()
     CleanAndClose();
     throw std::runtime_error("failed to get primary plane of drmDevice");
   }
+
+  if (aml_get_drmDevice_connected())
+    aml_init_drmDevice_display();
 }
 
 void CAMLDRMUtils::aml_init_drmDevice_display()

--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -1031,6 +1031,12 @@ bool CAMLDisplay::aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
   res->bFullScreen   = true;
   res->iSubtitles    = (int)(0.965 * res->iHeight);
   res->fPixelRatio   = 1.0f;
+
+  // Fix pixel ratio when 4:3 resolution is used on wide screen
+  const float res_ratio = static_cast<float>(res->iScreenWidth) / res->iScreenHeight;
+  if (res_ratio < 1.65f && aml_display_is_widescreen())
+    res->fPixelRatio = (16.0f / 9.0f) / res_ratio;
+
   res->strId         = fromMode;
   res->strMode       = StringUtils::Format("{:d}x{:d} @ {:.2f}{} - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
     res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");

--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -514,14 +514,14 @@ std::string CAMLDRMUtils::aml_get_drmDevice_modes(void)
 
 // set mode of drmDevice
 bool CAMLDRMUtils::aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::string mode,
-  std::string framebuffer_name, bool force_mode_switch)
+  const RenderStereoMode stereo_mode, std::string framebuffer_name, bool force_mode_switch)
 {
   bool ret = false;
 
   m_width = res.iWidth;
   m_height = res.iHeight;
   m_ScreenWidth = res.iScreenWidth;
-  m_ScreenHeight = res.iScreenHeight;
+  m_ScreenHeight = stereo_mode == RenderStereoMode::HARDWAREBASED ? res.iHeight : res.iScreenHeight;
 
   if (force_mode_switch)
   {
@@ -543,7 +543,7 @@ bool CAMLDRMUtils::aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::strin
     return ret;
   }
 
-  ret = aml_set_drmDevice_active(mode, true);
+  ret = aml_set_drmDevice_active(mode, stereo_mode, true);
 
   if (!ret && force_mode_switch)
     set_drmProp(m_connector->connector_id, "UPDATE", DRM_MODE_OBJECT_CONNECTOR, 1, NULL);
@@ -742,10 +742,11 @@ std::string CAMLDRMUtils::aml_get_drmDevice_preferred_mode()
   return mode;
 }
 
-bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, bool active)
+bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, const RenderStereoMode stereo_mode, bool active)
 {
   bool ret = false;
   drmModeModeInfoPtr drmDevicemode = NULL;
+  drmModeModeInfo syntheticMode = {};
 
   if (!StringUtils::EqualsNoCase(aml_get_drmDevice_mode(), mode))
   {
@@ -759,6 +760,17 @@ bool CAMLDRMUtils::aml_set_drmDevice_active(std::string mode, bool active)
         break;
       }
     }
+  }
+
+  if (drmDevicemode && stereo_mode == RenderStereoMode::HARDWAREBASED)
+  {
+    syntheticMode = *drmDevicemode;
+    syntheticMode.clock       *= 2;
+    syntheticMode.vdisplay    += syntheticMode.vtotal;
+    syntheticMode.vsync_start += syntheticMode.vtotal;
+    syntheticMode.vsync_end   += syntheticMode.vtotal;
+    syntheticMode.vtotal      *= 2;
+    drmDevicemode = &syntheticMode;
   }
 
   if (drmDevicemode != NULL)
@@ -826,6 +838,7 @@ void CAMLDRMUtils::FlipPage(uint32_t fb_id)
 
 CAMLDisplay::CAMLDisplay()
 :  m_amlDRMUtils(new CAMLDRMUtils)
+,  m_stereo_mode(RenderStereoMode::UNDEFINED)
 {
 }
 
@@ -857,16 +870,14 @@ bool CAMLDisplay::set_native_resolution(const RESOLUTION_INFO &res, std::string 
 
 void CAMLDisplay::handle_display_stereo_mode(const RenderStereoMode stereo_mode)
 {
-  static RenderStereoMode kernel_stereo_mode = RenderStereoMode::UNDEFINED;
-
-  if (kernel_stereo_mode == RenderStereoMode::UNDEFINED)
+  if (m_stereo_mode == RenderStereoMode::UNDEFINED)
   {
     CSysfsPath _kernel_stereo_mode{"/sys/class/amhdmitx/amhdmitx0/stereo_mode"};
     if (_kernel_stereo_mode.Exists())
-      kernel_stereo_mode = static_cast<RenderStereoMode>(_kernel_stereo_mode.Get<int>().value());
+      m_stereo_mode = static_cast<RenderStereoMode>(_kernel_stereo_mode.Get<int>().value());
   }
 
-  if (kernel_stereo_mode != stereo_mode)
+  if (m_stereo_mode != stereo_mode)
   {
     std::string command = "3doff";
     switch (stereo_mode)
@@ -887,7 +898,7 @@ void CAMLDisplay::handle_display_stereo_mode(const RenderStereoMode stereo_mode)
 
     CLog::Log(LOGDEBUG, "CAMLDisplay::{} setting new mode: {}", __FUNCTION__, command);
     CSysfsPath("/sys/class/amhdmitx/amhdmitx0/config", command);
-    kernel_stereo_mode = stereo_mode;
+    m_stereo_mode = stereo_mode;
   }
 }
 
@@ -919,7 +930,7 @@ bool CAMLDisplay::set_display_resolution(const RESOLUTION_INFO &res, std::string
   if (m_amlDRMUtils->aml_get_drmProperty("FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR) != fractional_rate)
     m_amlDRMUtils->aml_set_drmProperty("FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR, fractional_rate);
 
-  m_amlDRMUtils->aml_set_drmDevice_mode(res, mode, framebuffer_name, force_mode_switch);
+  m_amlDRMUtils->aml_set_drmDevice_mode(res, mode, m_stereo_mode, framebuffer_name, force_mode_switch);
 
   return true;
 }

--- a/xbmc/windowing/amlogic/AMLDisplay.h
+++ b/xbmc/windowing/amlogic/AMLDisplay.h
@@ -86,12 +86,12 @@ public:
   std::string aml_get_drmDevice_mode();
   std::string aml_get_drmDevice_modes();
   bool aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::string mode,
-    std::string framebuffer_name, bool force_mode_switch);
+    const RenderStereoMode stereo_mode, std::string framebuffer_name, bool force_mode_switch);
   int aml_get_drmProperty(std::string name, unsigned int obj_type);
   void aml_set_drmProperty(std::string name, unsigned int obj_type, unsigned int value);
   int aml_get_drmDevice_modes_count(drmModeConnection *connection);
   std::string aml_get_drmDevice_preferred_mode();
-  bool aml_set_drmDevice_active(std::string mode, bool active);
+  bool aml_set_drmDevice_active(std::string mode, const RenderStereoMode stereo_mode, bool active);
   bool aml_get_drmDevice_connected() const { return m_connection == DRM_MODE_CONNECTED; }
   void FlipPage(uint32_t fb_id);
 private:
@@ -142,7 +142,7 @@ public:
     { return m_amlDRMUtils->aml_get_drmProperty(name, obj_type); }
   void FlipPage(uint32_t fb_id) { m_amlDRMUtils->FlipPage(fb_id); }
   bool aml_set_drmDevice_active(bool active) const
-    { return m_amlDRMUtils->aml_set_drmDevice_active(m_amlDRMUtils->aml_get_drmDevice_mode(), active); }
+    { return m_amlDRMUtils->aml_set_drmDevice_active(m_amlDRMUtils->aml_get_drmDevice_mode(), m_stereo_mode, active); }
 
   bool GetHotPlug() { bool ret = m_bHotPlug; m_bHotPlug = false; return ret; }
   void SetHotPlug() { m_bHotPlug = true; }
@@ -150,4 +150,5 @@ private:
   std::unique_ptr<CAMLDRMUtils> m_amlDRMUtils;
   bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);
   bool m_bHotPlug = false;
+  RenderStereoMode m_stereo_mode;
 };

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -47,8 +47,7 @@ using namespace KODI;
 std::unique_ptr<CAMLDisplay> CWinSystemAmlogic::m_amlDisplay = nullptr;
 
 CWinSystemAmlogic::CWinSystemAmlogic()
-:  m_nativeWindow(NULL)
-,  m_libinput(new CLibInputHandler)
+:  m_libinput(new CLibInputHandler)
 ,  m_force_mode_switch(false)
 ,  m_fdMonitorId(-1)
 ,  m_udev(NULL)
@@ -57,15 +56,7 @@ CWinSystemAmlogic::CWinSystemAmlogic()
   const char *env_framebuffer = getenv("FRAMEBUFFER");
 
   m_amlDisplay = std::make_unique<CAMLDisplay>();
-
-  DllMali *m_dll = new DllMali;
-  if((m_dll->Load()))
-  {
-    CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem is a GBM system");
-    m_dll->Unload();
-    m_amlGBMUtils = std::make_unique<CAMLGBMUtils>(m_amlDisplay->aml_get_Device_handle());
-  }
-  delete m_dll, m_dll = NULL;
+  m_amlGBMUtils = std::make_unique<CAMLGBMUtils>(m_amlDisplay->aml_get_Device_handle());
 
   // default to framebuffer 0
   m_framebuffer_name = "fb0";
@@ -379,12 +370,6 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAmlogic::DestroyWindow()
 {
-  if (m_nativeWindow != NULL)
-  {
-    delete(m_nativeWindow);
-    m_nativeWindow = NULL;
-  }
-
   m_bWindowCreated = false;
   return true;
 }

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -169,6 +169,16 @@ void CWinSystemAmlogic::MonitorStop()
 void CWinSystemAmlogic::HotplugEvent()
 {
   m_amlDisplay->aml_init_drmDevice();
+  drmModeConnection connection;
+  int mode_count = m_amlDisplay->aml_get_display_modes_count(&connection);
+  if (connection == DRM_MODE_DISCONNECTED && mode_count == 1)
+  {
+    CLog::Log(LOGWARNING,
+      "CWinSystemAmlogic - HotplugEvent ignored while HDMI DRM connector is not ready ({:d} modes)",
+      mode_count);
+    MonitorStart();
+    return;
+  }
   std::string preferred_mode = m_amlDisplay->aml_get_preferred_mode();
   RESOLUTION res = static_cast<RESOLUTION>(RES_DESKTOP);
 
@@ -313,7 +323,8 @@ bool CWinSystemAmlogic::InitWindowSystem()
   {
     if (mode_count > 1)
     {
-      CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem Looks like display was hotplugged before Kodi start");
+      CLog::Log(LOGWARNING,
+        "CWinSystemAmlogic::InitWindowSystem HDMI modes are present but DRM connector is not ready, trigger hotplug");
       HotplugEvent();
     }
     else if (mode_count == 1)

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.h
@@ -15,27 +15,9 @@
 #include "windowing/WinSystem.h"
 #include "threads/SystemClock.h"
 #include "system_egl.h"
-#include <EGL/fbdev_window.h>
 #include <gbm.h>
 
 class IDispResource;
-
-class DllMaliInterface
-{
-public:
-  virtual ~DllMaliInterface() = default;
-  virtual struct gbm_device *gbm_create_device(int fd) = 0;
-};
-
-class DllMali : public DllDynamic, public DllMaliInterface
-{
-public:
-  DECLARE_DLL_WRAPPER(DllMali, "libMali.so")
-  DEFINE_METHOD1(struct gbm_device *, gbm_create_device, (int p1))
-  BEGIN_METHOD_RESOLVE()
-    RESOLVE_METHOD(gbm_create_device)
-  END_METHOD_RESOLVE()
-};
 
 class CWinSystemAmlogic : public CWinSystemBase
 {
@@ -71,7 +53,6 @@ public:
 protected:
   std::string m_framebuffer_name;
   EGLDisplay m_nativeDisplay;
-  fbdev_window *m_nativeWindow;
 
   RenderStereoMode m_stereo_mode;
 

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -44,21 +44,10 @@ bool CWinSystemAmlogicGLESContext::InitWindowSystem()
     return false;
   }
 
-  if (m_amlGBMUtils)
+  if (!m_pGLContext->CreatePlatformDisplay(m_amlGBMUtils->GetDevice(), m_amlGBMUtils->GetDevice()))
   {
-    if (!m_pGLContext->CreatePlatformDisplay(m_amlGBMUtils->GetDevice(), m_amlGBMUtils->GetDevice()))
-    {
-      m_pGLContext->Destroy();
-      return false;
-    }
-  }
-  else
-  {
-    if (!m_pGLContext->CreateDisplay(m_nativeDisplay))
-    {
-      m_pGLContext->Destroy();
-      return false;
-    }
+    m_pGLContext->Destroy();
+    return false;
   }
 
   if (!m_pGLContext->InitializeDisplay(EGL_OPENGL_ES_API))
@@ -92,8 +81,7 @@ bool CWinSystemAmlogicGLESContext::InitWindowSystem()
 
 bool CWinSystemAmlogicGLESContext::DestroyWindowSystem()
 {
-  if (m_amlGBMUtils && m_amlDisplay->aml_get_display_connected())
-    m_amlDisplay->aml_set_drmDevice_active(false);
+  m_amlDisplay->aml_set_drmDevice_active(false);
 
   m_pGLContext->DestroyContext();
   m_pGLContext->Destroy();
@@ -196,35 +184,19 @@ bool CWinSystemAmlogicGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (m_amlGBMUtils)
+  uint32_t format = m_pGLContext->GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
+  if (!m_amlGBMUtils->CreateSurface(res.iWidth, res.iHeight, format))
   {
-    uint32_t format = m_pGLContext->GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
-    if (!m_amlGBMUtils->CreateSurface(res.iWidth, res.iHeight, format))
-    {
-      CLog::Log(LOGDEBUG, "CWinSystemAmlogicGLESContext::{} - failed to create GBM surface", __FUNCTION__);
-      return false;
-    }
-
-    if (!m_pGLContext->CreatePlatformSurface(
-            m_amlGBMUtils->GetSurface(),
-            reinterpret_cast<EGLNativeWindowType>(m_amlGBMUtils->GetSurface())))
-    {
-      CLog::Log(LOGDEBUG, "CWinSystemAmlogicGLESContext::{} - failed to create CreatePlatformSurface", __FUNCTION__);
-      return false;
-    }
+    CLog::Log(LOGDEBUG, "CWinSystemAmlogicGLESContext::{} - failed to create GBM surface", __FUNCTION__);
+    return false;
   }
-  else
+
+  if (!m_pGLContext->CreatePlatformSurface(
+          m_amlGBMUtils->GetSurface(),
+          reinterpret_cast<EGLNativeWindowType>(m_amlGBMUtils->GetSurface())))
   {
-    if (m_nativeWindow == NULL)
-      m_nativeWindow = new fbdev_window;
-
-    m_nativeWindow->width = res.iWidth;
-    m_nativeWindow->height = res.iHeight;
-
-    if (!m_pGLContext->CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow)))
-    {
-      return false;
-    }
+    CLog::Log(LOGDEBUG, "CWinSystemAmlogicGLESContext::{} - failed to create CreatePlatformSurface", __FUNCTION__);
+    return false;
   }
 
   if (!m_pGLContext->BindContext())


### PR DESCRIPTION
Add HDR Vivid (T/UWA 005) metadata detection from HEVC SEI NALUs, following the HDR10+ detection pattern:

- HevcSei: add FindHdrVividSeiMessage, ContainsHdrVivid, RemoveHdrVividFromSeiNalu methods
- BitstreamConverter: detect HDR Vivid in SEI prefix NALUs
- StreamInfo/video_codec: add HDR_TYPE_HDRVIVID enum
- ProcessInfo: add SetIsHdrVivid/GetIsHdrVivid flags
- DVDVideoCodecAmlogic: wire up HDR Vivid from bitstream
- VideoPlayer: upgrade hdrType to HDR_TYPE_HDRVIVID when detected
- HDRCapabilities: add SupportsHDRVivid/SetHDRVivid
- SystemGUIInfo: report HDR Vivid in supported HDR types

Detection based on MediaInfoLib logic:
  ITU-T T.35 country_code=0x26 (China) terminal_provider_code=0x0004 terminal_provider_oriented_code=0x0005
