### PR TITLE
amlogic: replace GUI-scaling toggle with a GUI resolution limit setting

### DIFF
--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -548,10 +548,7 @@ bool CAMLDRMUtils::aml_set_drmDevice_mode(const RESOLUTION_INFO &res, std::strin
   if (!ret && force_mode_switch)
     set_drmProp(m_connector->connector_id, "UPDATE", DRM_MODE_OBJECT_CONNECTOR, 1, NULL);
 
-  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_COREELEC_AMLOGIC_DISABLEGUISCALING))
-    aml_set_framebuffer_resolution(res.iWidth, res.iHeight, framebuffer_name, !ret);
-  else
-    aml_set_framebuffer_resolution(res.iScreenWidth, res.iScreenHeight, framebuffer_name, !ret);
+  aml_set_framebuffer_resolution(res.iWidth, res.iHeight, framebuffer_name, !ret);
 
   CLog::Log(LOGDEBUG, "CAMLDRMUtils::{} - finished set drmDevice mode", __FUNCTION__);
 
@@ -1041,8 +1038,8 @@ bool CAMLDisplay::aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
     return false;
   }
 
-  res->iWidth = nativeGui ? width : std::min(width, 1920);
-  res->iHeight= nativeGui ? height : std::min(height, 1080);
+  res->iWidth  = std::min(nativeGui ? width  : (width  <= 1920 ? width  : width  / 2), 3840);
+  res->iHeight = std::min(nativeGui ? height : (height <= 1080 ? height : height / 2), 2160);
   res->iScreenWidth = width;
   res->iScreenHeight = height;
   res->dwFlags = (*smode == 'p') ? D3DPRESENTFLAG_PROGRESSIVE : D3DPRESENTFLAG_INTERLACED;


### PR DESCRIPTION
## Summary

`coreelec.amlogic.disableguiscaling` is a boolean:
- **off (default)**: cap the GUI render canvas at a hardcoded 1920x1080,
  then hardware-upscale it to the output resolution.
- **on**: render the GUI at the full native output resolution, no scaling.

On 8K-capable Amlogic hardware (tested: Ugoos SK1, S928X-K) the "on"
(native) path is broken — a GUI/OSD plane at the full native 7680px
width produces visible picture corruption. This reproduces independently
of video decode, DSC, chroma format, or FRL rate, so it's isolated to
the GUI/OSD compositing path itself, not anything video-pipeline
specific. Meanwhile the "off" path's hardcoded 1920x1080 ceiling leaves
8K output stuck with a needlessly low-res GUI even though the same
hardware's OSD plane handles up to at least 3840px wide cleanly.

Per review discussion, this keeps the existing boolean setting as-is and
instead fixes the underlying calculation in `aml_mode_to_resolution()`
(`xbmc/windowing/amlogic/AMLDisplay.cpp`):

| Mode | Old | New |
|---|---|---|
| off (scaled) | flat `min(w,1920) x min(h,1080)` regardless of output res | at/below 1920x1080: matches output natively; above: half the output resolution, capped at 3840x2160 |
| on (native) | full native output res, uncapped | `min(w,3840) x min(h,2160)` — capped at the confirmed-safe limit |

The framebuffer-resolution branch in `aml_set_drmDevice_mode()` is also
adjusted: it previously requested the full native `iScreenWidth`/`iScreenHeight`
for the actual framebuffer whenever "on" was set, which would still risk
the same corruption on 8K output. Since `res.iWidth`/`iHeight` is now
always already capped to a safe size in both branches, that special case
is removed and the capped size is used unconditionally.

## Test plan

Tested on Ugoos SK1 / S928X-K, builds `22.0-Piers_devel_20260701123556`
and `20260701141114` (this includes a real rebuild of the kernel with
`CONFIG_AMLOGIC_DSC=y`, see CoreELEC/CoreELEC#401, so 8K DSC output is
genuinely exercised here):

- [x] off (default) at 1080p output: `fb0` `1920,2160` — unchanged
- [x] off (default) at 4K output: `fb0` `1920,2160` — unchanged
- [x] off (default) at 8K output: `fb0` `3840,4320` — visibly sharper
      icons than the old flat 1920x1080 target
- [x] off (default) at 720p output: `fb0` `1280,1440` — matches the
      output natively, as expected (see edge case below)
- [x] on at 1080p output: `fb0` `1920,2160` — unchanged
- [x] on at 4K output: `fb0` `3840,4320` — unchanged (already at cap)
- [x] on at 8K output: `fb0` `3840,4320`, **clean picture** — previously
      this was a full native `7680,8640` framebuffer and corrupted
- [x] 8K60 AV1 video plays cleanly under "off", OSD responsive, `fb0`
      stays `3840,4320` throughout
- [x] Live on/off toggle at 8K output re-applies correctly each time
      (both branches converge to the same `3840,4320` at this output
      size specifically, by design — not a bug)
- [x] Edge case found *and fixed*: an earlier version of this PR gave
      `fb0` `1920,2160` for "off" mode at 720p output (upscale-then-
      downscale on lower-res hardware, a regression vs. the old
      `min(width,1920)` behaviour). Fixed by matching the output
      natively at or below 1920x1080 instead of flooring at a flat
      1920 — retested above, now correctly gives `1280,1440`.
- [ ] Not tested on non-SK1 hardware — all resolution tiers above
      (720p/1080p/4K/8K) are now hardware-confirmed on the SK1 itself,
      but not on other device models.