### PR TITLE
DemuxStreamSSIF: fix h264/MVC packages order

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.cpp
@@ -60,7 +60,7 @@ void CDemuxStreamSSIF::Flush()
   while (!m_MVCqueue.empty())
   {
     CDVDDemuxUtils::FreeDemuxPacket(m_MVCqueue.front());
-    m_MVCqueue.pop();
+    m_MVCqueue.pop_front();
   }
 }
 
@@ -103,7 +103,7 @@ DemuxPacket* CDemuxStreamSSIF::GetMVCPacket()
     if (tsH264 == tsMVC)
     {
       m_H264queue.pop();
-      m_MVCqueue.pop();
+      m_MVCqueue.pop_front();
 
       while (!m_H264queue.empty())
       {
@@ -120,22 +120,6 @@ DemuxPacket* CDemuxStreamSSIF::GetMVCPacket()
         else
           break;
       }
-      while (!m_MVCqueue.empty())
-      {
-        DemuxPacket* pkt = m_MVCqueue.front();
-        double ts = (pkt->dts != DVD_NOPTS_VALUE ? pkt->dts : pkt->pts);
-        if (ts == DVD_NOPTS_VALUE)
-        {
-#if defined(DEBUG_VERBOSE)
-          CLog::Log(LOGDEBUG, ">>> MVC merge mvc fragment: {:6}+{:6}, pts({:.3f}/{:.3f}) dts({:.3f}/{:.3f})", mvcpkt->iSize, pkt->iSize, mvcpkt->pts*1e-6, pkt->pts*1e-6, mvcpkt->dts*1e-6, pkt->dts*1e-6);
-#endif
-          mvcpkt = MergePacket(mvcpkt, pkt);
-          m_MVCqueue.pop();
-        }
-        else
-          break;
-      }
-
 #if defined(DEBUG_VERBOSE)
       CLog::Log(LOGDEBUG, ">>> MVC merge packet: {:6}+{:6}, pts({:.3f}/{:.3f}) dts({:.3f}/{:.3f})", h264pkt->iSize, mvcpkt->iSize, h264pkt->pts*1e-6, mvcpkt->pts*1e-6, h264pkt->dts*1e-6, mvcpkt->dts*1e-6);
 #endif
@@ -147,7 +131,7 @@ DemuxPacket* CDemuxStreamSSIF::GetMVCPacket()
       CLog::Log(LOGDEBUG, ">>> MVC discard  mvc: {:6}, pts({:.3f}) dts({:.3f})", mvcpkt->iSize, mvcpkt->pts*1e-6, mvcpkt->dts*1e-6);
 #endif
       CDVDDemuxUtils::FreeDemuxPacket(mvcpkt);
-      m_MVCqueue.pop();
+      m_MVCqueue.pop_front();
     }
     else
     {
@@ -167,10 +151,45 @@ DemuxPacket* CDemuxStreamSSIF::GetMVCPacket()
 
 void CDemuxStreamSSIF::AddMVCExtPacket(DemuxPacket* &mvcExtPkt)
 {
+  // Detect continuation fragments of MVC access units split at the SSIF interleave
+  // boundary.  In SSIF, when a dependent-view MVC AU exceeds the interleave unit
+  // size (~200KB), the remainder is carried in a new PES packet whose PTS is assigned
+  // by the transport-stream muxer — typically the PTS of the NEXT B-frame time slot.
+  // Without pre-merging, the continuation would be paired with the wrong base-view
+  // frame (the B-frame), corrupting both the IDR (truncated MVC) and the B-frame
+  // (oversized, wrong MVC data).
+  //
+  // Detection: Every genuine MVC access unit starts with a NAL start code
+  // (00 00 00 01 or 00 00 01) because the MPEG-TS demuxer outputs H.264 byte-stream
+  // format.  A continuation fragment, produced by a PES-level split in the middle of
+  // a NAL unit, does NOT start with a start code.  This is a reliable, disc-independent
+  // signal that doesn't depend on fragile size thresholds.
+
+  if (!m_MVCqueue.empty() && mvcExtPkt->iSize > 0)
+  {
+    bool startsWithStartCode = (mvcExtPkt->iSize >= 4 &&
+      mvcExtPkt->pData[0] == 0x00 && mvcExtPkt->pData[1] == 0x00 &&
+      (mvcExtPkt->pData[2] == 0x01 ||
+       (mvcExtPkt->pData[2] == 0x00 && mvcExtPkt->pData[3] == 0x01)));
+
+    if (!startsWithStartCode)
+    {
+      DemuxPacket* prevPkt = m_MVCqueue.back();
+      m_MVCqueue.pop_back();
+#if defined(DEBUG_VERBOSE)
+      CLog::Log(LOGDEBUG, ">>> MVC pre-merge continuation (no startcode): {:6}+{:6}, prev_pts({:.3f}) cont_pts({:.3f})",
+                prevPkt->iSize, mvcExtPkt->iSize, prevPkt->pts*1e-6, mvcExtPkt->pts*1e-6);
+#endif
+      DemuxPacket* merged = MergePacket(prevPkt, mvcExtPkt);
+      m_MVCqueue.push_back(merged);
+      return;
+    }
+  }
+
 #if defined(DEBUG_VERBOSE)
     CLog::Log(LOGDEBUG, ">>> MVC add mvc  packet: pts: {:.3f} dts: {:.3f}", mvcExtPkt->pts*1e-6, mvcExtPkt->dts*1e-6);
 #endif
-  m_MVCqueue.push(mvcExtPkt);
+  m_MVCqueue.push_back(mvcExtPkt);
 }
 
 bool CDemuxStreamSSIF::FillMVCQueue(double dtsBase)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxStreamSSIF.h
@@ -24,6 +24,7 @@
 #include "DVDInputStreams/DVDInputStreamBluray.h"
 #endif
 #include "DVDInputStreams/DVDInputStream.h"
+#include <deque>
 #include <queue>
 
 extern "C" {
@@ -53,7 +54,9 @@ private:
 
   std::shared_ptr<CDVDInputStream::IExtentionStream> m_bluRay = nullptr;
   std::queue<DemuxPacket*> m_H264queue;
-  std::queue<DemuxPacket*> m_MVCqueue;
+  // deque so we can peek the second element (m_MVCqueue[1]) when reassembling a split
+  // dependent access unit, and splice a reassembled packet back onto the front.
+  std::deque<DemuxPacket*> m_MVCqueue;
   int m_h264StreamId = -1;
   int m_mvcStreamId = -1;
 };


### PR DESCRIPTION
## Description
Bugfix: Many older 3D Blu-Ray releases mainly from Kino Lorber, Sony or Warner had playback issues. The dependent video had decoding artifacts or black dropouts or the video freezed after some time. Some BDs didn't play at all. Together with Claude I figured out that the MVC video frames weren't assigned correctly to their respective H.264 base view frames. This is fixed with a new NALu parser.

## Motivation and context
I'd like to stay up to date with CoreELEC 22 and also be able to watch my 3D Blu-Ray library as long as possible. Claude helped me to analyze the problem and provided the code.

## How has this been tested?
Several 3D BD ISOs. Every ISO which had problems before, plays without issues and I didn't notice any regression with any ISO which worked before already.

## What is the effect on users?
3D BDs play without issues. Since only 3D MVC demuxer code is touched, no side effects on any other usecase is expected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
