### PR TITLE
Fix memory leak in Amlogic video decoder path

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -602,6 +602,8 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAmlogic::GetPicture(VideoPicture* pVideoP
 
   if (retVal == VC_PICTURE)
   {
+    if (pVideoPicture->videoBuffer)
+      pVideoPicture->videoBuffer->Release();
     pVideoPicture->videoBuffer = nullptr;
     pVideoPicture->SetParams(m_videobuffer);
 


### PR DESCRIPTION
## Description
CDVDVideoCodecAmlogic::GetPicture() leaks one CAMLVideoBuffer reference per decoded frame, causing steady, unbounded kodi.bin RSS growth (~1MB/minute observed during the playback of the live TV streams).

## Root cause
`pVideoPicture->videoBuffer` is a persistent field (`VideoPlayerVideo::m_picture.videoBuffer`) that gets overwritten on every call to` GetPicture()`:

```
if (retVal == VC_PICTURE)
{
  pVideoPicture->videoBuffer = nullptr;   // previous buffer reference dropped, never released
  pVideoPicture->SetParams(m_videobuffer);
  pVideoPicture->videoBuffer = m_videoBufferPool->Get();
  ...
}
```
The previous buffer's reference count is never decremented, so `CAMLVideoBufferPool::Return()` is never invoked and `CAMLVideoBufferPool::m_videoBuffers` grows without bound for the life of playback.

The FFmpeg codec path (DVDVideoCodecFFmpeg.cpp) already does this correctly:

```
if (pVideoPicture->videoBuffer)
  pVideoPicture->videoBuffer->Release();
pVideoPicture->videoBuffer = nullptr;
```
## Fix
Add the missing Release() call before reassigning `pVideoPicture->videoBuffer`, matching the pattern already used by the FFmpeg codec path.