### PR TITLE
OverlayRendererUtil: fix inverted guard in GetStereoscopicDepth

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -274,8 +274,8 @@ bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
 
 int GetStereoscopicDepth(bool isPgs, int subtitleDepth)
 {
-  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::MONO &&
-      CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::OFF)
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RenderStereoMode::MONO ||
+      CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RenderStereoMode::OFF)
   {
     // 2D display, so there's no subtitle depth
     return 0;


### PR DESCRIPTION
## Description

`GetStereoscopicDepth()` returns 0 whenever the stereo mode is anything other than `MONO` or `OFF` — that is, in every stereoscopic mode, which is the only case where subtitle depth means anything. So the configured value is never read and `subtitles.stereoscopicdepth` does nothing.

The condition predates 83f722b7db ("MVC PGS subtitles"); before it, the same test selected the stereoscopic case in order to *apply* the depth. That commit replaced the body of the block with an early `return 0` but left the condition unchanged, so it now selects the opposite case to the one its own comment describes. The `depth += subtitleDepth` line below the guard became unreachable at the same time.

The setting defaults to 0 and sits at settings level 2, which is probably why this went unnoticed — it ships off, and anyone who raised it saw no change and would conclude the feature was unsupported rather than broken.

### Not a second attempt at #58

#58 contained this same guard flip and was closed by its author. It aimed at the disc's **authored** MVC depth, which does not work: `isPgs` is never set, and nothing parses the per-frame offsets out of the dependent-view SEI. This PR does not attempt that, and that conclusion stands.

What is left over is the other half. As the author put it before closing: *"With my changes `depth` is always set to the offset value of the kodi settings."* That is not a side effect — it is what the setting is for, it is what upstream Kodi does, and it stopped working here in 83f722b7db. This PR restores only that. If you would still rather leave the function alone, the setting could be hidden instead, so it stops offering a control that cannot do anything.

## Motivation and context

`subtitles.stereoscopicdepth` is a user-facing setting that currently has no effect in any stereoscopic mode. This is a regression against upstream Kodi behaviour, introduced by 83f722b7db.

## How has this been tested?

Homatics Box R 4K plus, CoreELEC 22 built from this branch, frame-packed 3D MVC title (`stereoscopicmode: hardware_based`, 1080p24hz), PGS subtitles, `subtitles.stereoscopicdepth` at 10.

- Before: subtitles flat in the screen plane at any depth value.
- After: separated per eye and seen in front of the picture, with the expected doubled image when viewed without glasses.

The per-eye machinery it relies on is intact — the GUI is rendered twice as LEFT then RIGHT, `GraphicContext` offsets the right pass into the lower half of the frame-packed buffer, and 0cf018611b gives the GUI a framebuffer spanning both eyes. Only the early `return 0` stopped an offset being applied.

Scope is the configured depth only. The per-overlay MVC depth stays inert: `COverlay::m_pgsSubtitle` is never assigned, and nothing reads `DemuxPacket::subtitlePlane`. Wiring those up is a feature, needs a real disc to test, and belongs upstream in `xbmc/xbmc` where all the files involved live.

## What is the effect on users?

The "3D subtitle depth" setting works again in stereoscopic modes. No change for 2D playback, and none at the default value of 0.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

---

**This change was written with AI assistance.** The diagnosis and the code were produced by me working with Anthropic's Claude; the commit carries a `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` trailer.
