### PR TITLE
WinSystemAmlogic: read HDR capabilities on display events

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -213,6 +213,7 @@ void CWinSystemAmlogic::HotplugEvent()
     CLog::Log(LOGDEBUG, "CWinSystemAmlogic - HotplugEvent, preferred mode: {}, display mode: {}",
       preferred_mode, CDisplaySettings::GetInstance().GetResolutionInfo(res).strId);
   }
+  else
     CLog::Log(LOGWARNING, "CWinSystemAmlogic - HotplugEvent, no preferred mode defined, use display mode: {}",
       CDisplaySettings::GetInstance().GetResolutionInfo(res).strId);
 

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -188,6 +188,9 @@ void CWinSystemAmlogic::HotplugEvent()
       mode_count);
     return;
   }
+
+  UpdateHDRCapabilities();
+
   std::string preferred_mode = m_amlDisplay->aml_get_preferred_mode();
   RESOLUTION res = static_cast<RESOLUTION>(RES_DESKTOP);
 
@@ -358,6 +361,8 @@ bool CWinSystemAmlogic::InitWindowSystem()
     }
   }
 
+  UpdateHDRCapabilities();
+
   MonitorStart();
 
   // kill a running animation
@@ -401,7 +406,6 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
   if ((ret = m_amlDisplay->set_native_resolution(res, m_framebuffer_name, m_stereo_mode,
                                            m_force_mode_switch, m_hotplug_mode_switch)))
   {
-    m_hdr_caps_initialized = false;
     m_bWindowCreated = true;
   }
 
@@ -464,40 +468,42 @@ void CWinSystemAmlogic::UpdateResolutions()
   RefreshResolutions();
 }
 
-bool CWinSystemAmlogic::IsHDRDisplay()
+void CWinSystemAmlogic::UpdateHDRCapabilities()
 {
-  if (!m_hdr_caps_initialized)
+  // built locally so a stream opening during the update cannot see empty caps
+  CHDRCapabilities caps;
+  CSysfsPath hdr_cap{"/sys/class/amhdmitx/amhdmitx0/hdr_cap"};
+  CSysfsPath dv_cap{"/sys/class/amhdmitx/amhdmitx0/dv_cap"};
+  std::string valstr;
+
+  if (hdr_cap.Exists())
   {
-    CSysfsPath hdr_cap{"/sys/class/amhdmitx/amhdmitx0/hdr_cap"};
-    CSysfsPath dv_cap{"/sys/class/amhdmitx/amhdmitx0/dv_cap"};
-    std::string valstr;
+    valstr = hdr_cap.Get<std::string>().value();
+    if (valstr.find("Traditional HDR: 1") != std::string::npos ||
+        valstr.find("SMPTE ST 2084: 1") != std::string::npos)
+      caps.SetHDR10();
 
-    if (hdr_cap.Exists())
-    {
-      valstr = hdr_cap.Get<std::string>().value();
-      if (valstr.find("Traditional HDR: 1") != std::string::npos ||
-          valstr.find("SMPTE ST 2084: 1") != std::string::npos)
-        m_hdr_caps.SetHDR10();
+    if (valstr.find("HDR10Plus Supported: 1") != std::string::npos)
+      caps.SetHDR10Plus();
 
-      if (valstr.find("HDR10Plus Supported: 1") != std::string::npos)
-        m_hdr_caps.SetHDR10Plus();
-
-      if (valstr.find("Hybrid Log-Gamma: 1") != std::string::npos)
-        m_hdr_caps.SetHLG();
-    }
-
-    if (dv_cap.Exists())
-    {
-      valstr = dv_cap.Get<std::string>().value();
-      if (valstr.find("2160p30hz: 1") != std::string::npos)
-        m_hdr_caps.SetDolbyVision();
-      else if (valstr.find("2160p60hz: 1") != std::string::npos)
-        m_hdr_caps.SetDolbyVision4k60();
-    }
-
-    m_hdr_caps_initialized = true;
+    if (valstr.find("Hybrid Log-Gamma: 1") != std::string::npos)
+      caps.SetHLG();
   }
 
+  if (dv_cap.Exists())
+  {
+    valstr = dv_cap.Get<std::string>().value();
+    if (valstr.find("2160p30hz: 1") != std::string::npos)
+      caps.SetDolbyVision();
+    else if (valstr.find("2160p60hz: 1") != std::string::npos)
+      caps.SetDolbyVision4k60();
+  }
+
+  m_hdr_caps = caps;
+}
+
+bool CWinSystemAmlogic::IsHDRDisplay()
+{
   return (m_hdr_caps.SupportsHDR10() | m_hdr_caps.SupportsHDR10Plus() | m_hdr_caps.SupportsHLG() |
          (m_hdr_caps.SupportsDolbyVision() != DolbyVisionFormat::DOLBYVISION_TYPE_NONE));
 }

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.h
@@ -72,7 +72,6 @@ protected:
   std::vector<IDispResource*> m_resources;
   std::unique_ptr<CLibInputHandler> m_libinput;
   CHDRCapabilities m_hdr_caps;
-  bool m_hdr_caps_initialized;
   bool m_force_mode_switch;
   bool m_hotplug_mode_switch{false};
   bool m_presentationReady{false};
@@ -89,6 +88,7 @@ private:
 
   void RefreshResolutions();
   void HotplugEvent();
+  void UpdateHDRCapabilities();
   static void FDEventCallback(int id, int fd, short revents, void *data);
 
   int m_fdMonitorId;


### PR DESCRIPTION
Two fixes in the Amlogic window system, following up on the recent hotplug rework (tip a730b2d675b5117d097b9c08740b4605f5f04704).

The main change moves the HDR capability cache onto the event plumbing that rework introduced. With display changes now arriving as hotplug events, hdr_cap and dv_cap can be read exactly where the display changes: once at window system init and again on each hotplug, rebuilding the object every time so it always describes the current display. Everything else, including the per-frame IsHDRDisplay path, becomes a plain read of that cache.

Before the rework there was no reliable in-process signal for a sink change, so lazy caching was the only workable shape. This new approach keeps what that caching fixed in #72 (these sysfs reads can stall on the hdmitx driver during a mode switch) while closing its gaps: the flag-only setters could carry a previous panel's capabilities across a sink swap, the codec could query the cache before anything filled it on a boot straight into playback, and the init flag itself was never initialized. An unplug keeps the last known capabilities on purpose, so a handshake blip cannot latch empty capabilities into a running stream.

The second commit restores an else lost in an earlier rework, so the missing preferred mode warning no longer fires on every hotplug.

Tested on an Ugoos AM9 Pro with an LG C4. The System Info HDR row populates at boot through the new path, and an HDMI replug repopulates it and no longer logs the spurious warning.
