### PR TITLE
AMLDisplay: derive the fractional refresh rates in double

### DIFF
--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -23,6 +23,16 @@
 #include "utils/RegExp.h"
 #include "windowing/GraphicContext.h"
 
+namespace
+{
+constexpr float FractionalRate(float rate)
+{
+  // Divide in double: in float the result lands one ULP low. Widened explicitly
+  // for -Werror=double-promotion.
+  return static_cast<float>(static_cast<double>(rate) / 1.001);
+}
+} // unnamed namespace
+
 void FbDestroyCallback(gbm_bo* bo, void* data)
 {
   drm_fb* fb = static_cast<drm_fb*>(data);
@@ -1237,7 +1247,7 @@ bool CAMLDisplay::aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
     case 23:
     case 29:
     case 59:
-      res->fRefreshRate = (float)((rrate + 1)/1.001f);
+      res->fRefreshRate = FractionalRate(rrate + 1);
       break;
     default:
       res->fRefreshRate = (float)rrate;
@@ -1278,7 +1288,7 @@ bool CAMLDisplay::aml_get_native_resolution(RESOLUTION_INFO *res)
   bool result = aml_mode_to_resolution(mode.c_str(), res);
 
   if (m_amlDRMUtils->aml_get_drmProperty("FRAC_RATE_POLICY", DRM_MODE_OBJECT_CONNECTOR) == 1)
-    res->fRefreshRate /= 1.001f;
+    res->fRefreshRate = FractionalRate(res->fRefreshRate);
 
   return result;
 }
@@ -1339,7 +1349,7 @@ bool CAMLDisplay::aml_probe_resolutions(std::vector<RESOLUTION_INFO> &resolution
           case 24:
           case 30:
           case 60:
-            res.fRefreshRate /= 1.001f;
+            res.fRefreshRate = FractionalRate(res.fRefreshRate);
             res.strMode       = StringUtils::Format("{:d}x{:d} @ {:.2f}{} - Full Screen", res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
               res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
             resolutions.push_back(res);


### PR DESCRIPTION
## Description

The 1000/1001 refresh modes are derived with a `1.001f` divide. That float is not exactly 1.001, so the resulting rate lands one ULP below the rate the player derives from the same ratio in double — as close as two floats can be without being equal, which is enough to defeat an equality test.

This derives the three fractional sites in `AMLDisplay.cpp` in double instead, via a small `FractionalRate()` helper, so the mode rate and the content rate compare bit for bit. Integer modes never divide and are untouched.

## Motivation and context

`CRenderManager::CheckEnableClockSync()` decides whether the display is already running at the content rate with `if (diff && diff < 0.0005)` — the `diff &&` being the perfect-match guard added in 74c3edd2f5 ("RenderManager: CheckEnableClockSync: Do not do a vsync adjust on perfect match").

On Amlogic that guard can never fire for a fractional rate, because `diff` is small than 0. Clock sync therefore stays *enabled* on what is actually a perfect match, `m_vSyncAdjust` becomes non-zero, and `CDVDClock::ErrorAdjust()`
switches from `adjustment = error` to `adjustment = ±m_frameTime` and calls `Discontinuity()` — moving the master clock by a whole frame (41.7 ms at 23.976). The visible result is a picture drawn twice or skipped, worst on panning shots.

Integer rates (24.000, 25.000, …) were never affected: they never divide, so they already compared equal and already had clock sync off.

## How has this been tested?

Amlogic S922X (g12b), Ugoos AM6B Plus, CoreELEC 22 `Amlogic-ce` build.

- Numerically verified the float values either side of the change. After it, 23.976, 29.97 and 59.94 are bit-identical between the mode and the content rate, so the display/content ratio is exactly `1.0` / `2.0`. 3:2 pulldown (23.976 content on a 59.94 display) still yields 2.4999999 and is correctly *not* treated as a match.

## What is the effect on users?

Fixes intermittent frame duplication/drops on Amlogic when the display is running at exactly the content rate — i.e. 23.976 / 29.97 / 59.94 content with "Adjust display refresh rate" enabled. Integer frame rates are unaffected.

## Screenshots (if appropriate):

NA

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed