### PR TITLE
AMLDisplay: force the modeset when frame packing starts or stops

### DIFF
--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
+++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
@@ -1037,6 +1037,18 @@ bool CAMLDisplay::set_native_resolution(const RESOLUTION_INFO &res, std::string 
 {
   bool result = false;
 
+  RenderStereoMode previous_stereo_mode = m_stereo_mode;
+  if (previous_stereo_mode == RenderStereoMode::UNDEFINED)
+  {
+    CSysfsPath _kernel_stereo_mode{"/sys/class/amhdmitx/amhdmitx0/stereo_mode"};
+    if (_kernel_stereo_mode.Exists())
+      previous_stereo_mode = static_cast<RenderStereoMode>(_kernel_stereo_mode.Get<int>().value());
+  }
+  if (previous_stereo_mode != stereo_mode &&
+      (previous_stereo_mode == RenderStereoMode::HARDWAREBASED ||
+       stereo_mode == RenderStereoMode::HARDWAREBASED))
+    force_mode_switch = true;
+
   if (aml_get_cpufamily_id() < AML_T7)
   {
     handle_display_stereo_mode(stereo_mode);


### PR DESCRIPTION

Frame packing is the same mode name with a doubled timing. `aml_set_drmDevice_active()` only performs
the modeset when `force_mode_switch` is set or the mode name differs from the current one, so when the
display is already at `1080p24hz` - the previous title was 1080p24, or a 3D title in a playlist follows
another - a frame-packed title sends `3dfp` to the driver without a modeset. The driver keeps the 2D
timing: `vinfo` stays at 1080 lines, no VSIF is sent, and a frame-packing projector shows the top eye
stretched with no 3D.

Force the modeset when the stereo mode switches into or out of `HARDWAREBASED`. `m_stereo_mode` is
`UNDEFINED` before the first switch, so the kernel's `stereo_mode` is read for the comparison, as
`handle_display_stereo_mode()` already does.

Measured on an Ugoos AM9 Pro (S905X5M, hdmitx21) against a JVC DLA-RS4100 through an HDFury VRROOM:

- nightly 20260904: playlist `TAB clip (1080p24) -> MVC clip`: `display/mode 1080p24hz`, `stereo_mode 8`,
  `vinfo height 1080`, `3d_info 0`; projector "1080p 24", top half of the frame stretched, no 3D. Same
  clip started from 2160p25: `height 2205`, `3d_info 2`, projector "1080p 24(FP)", correct 3D.
- with this change (same playlist): `height 2205`, `3d_info 2`, and back to `height 1080`, `3d_info 0`
  on stop.

`videoplayer.adjustrefreshrate` = "On start/stop" hides the problem, because every stop returns to
the desktop mode and the next start is a real modeset; "On start" and playlists expose it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
